### PR TITLE
Phase 3: 認証・認可（JWT / HttpOnly Cookie / CSRF）

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
 
 COPY . .
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.dependencies import get_current_user, verify_csrf_token
+from app.core.security import create_access_token, generate_csrf_token
+from app.db.database import get_db
+from app.models.user import User
+from app.schemas.auth import LoginRequest, RegisterRequest
+from app.schemas.user import UserResponse
+from app.services import auth_service
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+def _set_auth_cookies(response: Response, *, user_id: int, role: str) -> None:
+    access_token = create_access_token(user_id=user_id, role=role)
+    csrf_token = generate_csrf_token()
+
+    response.set_cookie(
+        key=settings.access_token_cookie_name,
+        value=access_token,
+        httponly=True,
+        secure=settings.cookie_secure,
+        samesite="lax",
+        max_age=settings.jwt_expire_minutes * 60,
+    )
+    response.set_cookie(
+        key=settings.csrf_token_cookie_name,
+        value=csrf_token,
+        httponly=False,
+        secure=settings.cookie_secure,
+        samesite="lax",
+        max_age=settings.jwt_expire_minutes * 60,
+    )
+
+
+def _clear_auth_cookies(response: Response) -> None:
+    response.delete_cookie(settings.access_token_cookie_name)
+    response.delete_cookie(settings.csrf_token_cookie_name)
+
+
+@router.post("/register", response_model=UserResponse, status_code=201)
+def register(payload: RegisterRequest, db: Session = Depends(get_db)) -> User:
+    return auth_service.register_user(db, username=payload.username, password=payload.password)
+
+
+@router.post("/login", response_model=UserResponse)
+def login(payload: LoginRequest, response: Response, db: Session = Depends(get_db)) -> User:
+    user = auth_service.authenticate(db, username=payload.username, password=payload.password)
+    _set_auth_cookies(response, user_id=user.id, role=user.role)
+    return user
+
+
+@router.post(
+    "/logout",
+    status_code=204,
+    dependencies=[Depends(verify_csrf_token)],
+)
+def logout(response: Response, current_user: User = Depends(get_current_user)):
+    _clear_auth_cookies(response)
+
+
+@router.get("/me", response_model=UserResponse)
+def me(current_user: User = Depends(get_current_user)) -> User:
+    return current_user

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,6 +12,10 @@ class Settings(BaseSettings):
     cookie_secure: bool = False
     timezone: str = "Asia/Tokyo"
 
+    access_token_cookie_name: str = "access_token"
+    csrf_token_cookie_name: str = "csrf_token"
+    csrf_token_header_name: str = "X-CSRF-Token"
+
     cors_allow_origins: list[str] = ["http://localhost:3000"]
 
     seed_admin_username: str = "admin"

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from fastapi import Depends, Request
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.security import decode_access_token
+from app.db.database import get_db
+from app.exceptions.exceptions import (
+    AdminRequiredError,
+    AuthenticationRequiredError,
+    CsrfTokenInvalidError,
+)
+from app.models.user import User
+from app.repositories import user_repository
+
+
+def get_current_user(request: Request, db: Session = Depends(get_db)) -> User:
+    token = request.cookies.get(settings.access_token_cookie_name)
+    if token is None:
+        raise AuthenticationRequiredError("認証が必要です")
+
+    payload = decode_access_token(token)
+    user_id = int(payload["sub"])
+    user = user_repository.get_by_id(db, user_id)
+    if user is None:
+        raise AuthenticationRequiredError("認証が必要です")
+    return user
+
+
+def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role != "ADMIN":
+        raise AdminRequiredError("管理者権限が必要です")
+    return current_user
+
+
+def verify_csrf_token(request: Request) -> None:
+    cookie_token = request.cookies.get(settings.csrf_token_cookie_name)
+    header_token = request.headers.get(settings.csrf_token_header_name)
+    if not cookie_token or not header_token or cookie_token != header_token:
+        raise CsrfTokenInvalidError("CSRFトークンが無効です")

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,11 @@
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from jose import JWTError, jwt
 from passlib.context import CryptContext
+
+from app.core.config import settings
+from app.exceptions.exceptions import InvalidTokenError, TokenExpiredError
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -9,3 +16,22 @@ def hash_password(password: str) -> str:
 
 def verify_password(plain_password: str, password_hash: str) -> bool:
     return pwd_context.verify(plain_password, password_hash)
+
+
+def create_access_token(*, user_id: int, role: str) -> str:
+    expire = datetime.now(UTC) + timedelta(minutes=settings.jwt_expire_minutes)
+    payload = {"sub": str(user_id), "role": role, "exp": expire}
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def decode_access_token(token: str) -> dict:
+    try:
+        return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+    except jwt.ExpiredSignatureError as exc:
+        raise TokenExpiredError("認証の有効期限が切れています") from exc
+    except JWTError as exc:
+        raise InvalidTokenError("認証情報が無効です") from exc
+
+
+def generate_csrf_token() -> str:
+    return secrets.token_urlsafe(32)

--- a/backend/app/exceptions/exceptions.py
+++ b/backend/app/exceptions/exceptions.py
@@ -1,0 +1,48 @@
+class AppError(Exception):
+    status_code: int = 400
+    code: str = "INVALID_REQUEST"
+
+    def __init__(self, message: str, details: dict | None = None):
+        self.message = message
+        self.details = details
+        super().__init__(message)
+
+
+class AuthenticationRequiredError(AppError):
+    status_code = 401
+    code = "AUTHENTICATION_REQUIRED"
+
+
+class InvalidCredentialsError(AppError):
+    status_code = 401
+    code = "INVALID_CREDENTIALS"
+
+
+class InvalidTokenError(AppError):
+    status_code = 401
+    code = "INVALID_TOKEN"
+
+
+class TokenExpiredError(AppError):
+    status_code = 401
+    code = "TOKEN_EXPIRED"
+
+
+class AdminRequiredError(AppError):
+    status_code = 403
+    code = "ADMIN_REQUIRED"
+
+
+class CsrfTokenInvalidError(AppError):
+    status_code = 403
+    code = "CSRF_TOKEN_INVALID"
+
+
+class UsernameAlreadyExistsError(AppError):
+    status_code = 409
+    code = "USERNAME_ALREADY_EXISTS"
+
+
+class ValidationError(AppError):
+    status_code = 422
+    code = "VALIDATION_ERROR"

--- a/backend/app/exceptions/handlers.py
+++ b/backend/app/exceptions/handlers.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from app.exceptions.exceptions import AppError
+
+
+def _error_body(code: str, message: str, details: dict | None = None) -> dict:
+    body = {"error": {"code": code, "message": message}}
+    if details:
+        body["error"]["details"] = details
+    return body
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(AppError)
+    async def app_error_handler(request: Request, exc: AppError) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=_error_body(exc.code, exc.message, exc.details),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error_handler(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        details = {}
+        for error in exc.errors():
+            field = ".".join(str(part) for part in error["loc"][1:]) or "_"
+            message = error["msg"]
+            if message.startswith("Value error, "):
+                message = message.removeprefix("Value error, ")
+            details[field] = message
+        return JSONResponse(
+            status_code=422,
+            content=_error_body("VALIDATION_ERROR", "入力内容に誤りがあります", details),
+        )
+
+    @app.exception_handler(Exception)
+    async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
+        return JSONResponse(
+            status_code=500,
+            content=_error_body("INTERNAL_SERVER_ERROR", "サーバーエラーが発生しました"),
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.auth import router as auth_router
 from app.core.config import settings
+from app.exceptions.handlers import register_exception_handlers
 
 app = FastAPI(title="StudyLog API")
 
@@ -12,6 +14,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+register_exception_handlers(app)
+
+app.include_router(auth_router)
 
 
 @app.get("/health")

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+
+
+def get_by_username(db: Session, username: str) -> User | None:
+    return db.query(User).filter(User.username == username).first()
+
+
+def get_by_id(db: Session, user_id: int) -> User | None:
+    return db.query(User).filter(User.id == user_id).first()
+
+
+def create(db: Session, *, username: str, password_hash: str, role: str = "USER") -> User:
+    user = User(username=username, password_hash=password_hash, role=role)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,51 @@
+import re
+
+from pydantic import BaseModel, field_validator, model_validator
+
+USERNAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,25}$")
+PASSWORD_LOWER_PATTERN = re.compile(r"[a-z]")
+PASSWORD_UPPER_PATTERN = re.compile(r"[A-Z]")
+PASSWORD_DIGIT_PATTERN = re.compile(r"[0-9]")
+
+
+def validate_password_strength(password: str) -> str:
+    if not (1 <= len(password) <= 50):
+        raise ValueError("パスワードは50文字以内で入力してください")
+    if not PASSWORD_LOWER_PATTERN.search(password):
+        raise ValueError("パスワードは小文字を1文字以上含めてください")
+    if not PASSWORD_UPPER_PATTERN.search(password):
+        raise ValueError("パスワードは大文字を1文字以上含めてください")
+    if not PASSWORD_DIGIT_PATTERN.search(password):
+        raise ValueError("パスワードは数字を1文字以上含めてください")
+    return password
+
+
+class RegisterRequest(BaseModel):
+    username: str
+    password: str
+    password_confirmation: str
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, value: str) -> str:
+        if not USERNAME_PATTERN.match(value):
+            raise ValueError(
+                "ユーザー名は1〜25文字の半角英数字・ハイフン・アンダースコアで入力してください"
+            )
+        return value
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, value: str) -> str:
+        return validate_password_strength(value)
+
+    @model_validator(mode="after")
+    def validate_password_match(self) -> "RegisterRequest":
+        if self.password != self.password_confirmation:
+            raise ValueError("パスワードが一致しません")
+        return self
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str

--- a/backend/app/schemas/error.py
+++ b/backend/app/schemas/error.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class ErrorDetail(BaseModel):
+    code: str
+    message: str
+    details: dict | None = None
+
+
+class ErrorResponse(BaseModel):
+    error: ErrorDetail

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    username: str
+    role: str

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_password, verify_password
+from app.exceptions.exceptions import InvalidCredentialsError, UsernameAlreadyExistsError
+from app.models.user import User
+from app.repositories import user_repository
+
+
+def register_user(db: Session, *, username: str, password: str) -> User:
+    if user_repository.get_by_username(db, username) is not None:
+        raise UsernameAlreadyExistsError("このユーザー名は既に使用されています。")
+    password_hash = hash_password(password)
+    return user_repository.create(db, username=username, password_hash=password_hash, role="USER")
+
+
+def authenticate(db: Session, *, username: str, password: str) -> User:
+    user = user_repository.get_by_username(db, username)
+    if user is None or not verify_password(password, user.password_hash):
+        raise InvalidCredentialsError("ユーザー名またはパスワードが正しくありません。")
+    return user

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,6 +5,11 @@ extend-exclude = ["alembic/versions"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "B", "UP"]
+# B008: FastAPI's Depends()/Query() pattern relies on call-in-default-argument.
+ignore = ["B008"]
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,49 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+from app.db.database import Base, get_db
+from app.main import app
+
+TEST_DATABASE_URL = settings.database_url
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _create_test_database():
+    engine = create_engine(TEST_DATABASE_URL)
+    Base.metadata.create_all(bind=engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine(TEST_DATABASE_URL)
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = session_local()
+    try:
+        yield session
+    finally:
+        session.close()
+        with engine.connect() as conn:
+            conn.execute(text("SET FOREIGN_KEY_CHECKS=0"))
+            for table in Base.metadata.sorted_tables:
+                conn.execute(text(f"TRUNCATE TABLE {table.name}"))
+            conn.execute(text("SET FOREIGN_KEY_CHECKS=1"))
+            conn.commit()
+        engine.dispose()
+
+
+@pytest.fixture
+def client(db_session):
+    def _override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,127 @@
+def register(client, username="testuser", password="Password1"):
+    return client.post(
+        "/api/auth/register",
+        json={
+            "username": username,
+            "password": password,
+            "password_confirmation": password,
+        },
+    )
+
+
+def test_register_success(client):
+    response = register(client)
+    assert response.status_code == 201
+    body = response.json()
+    assert body["username"] == "testuser"
+    assert body["role"] == "USER"
+
+
+def test_register_duplicate_username(client):
+    register(client)
+    response = register(client)
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "USERNAME_ALREADY_EXISTS"
+
+
+def test_register_password_mismatch(client):
+    response = client.post(
+        "/api/auth/register",
+        json={
+            "username": "testuser",
+            "password": "Password1",
+            "password_confirmation": "Different1",
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_register_weak_password(client):
+    response = client.post(
+        "/api/auth/register",
+        json={
+            "username": "testuser",
+            "password": "password",
+            "password_confirmation": "password",
+        },
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_login_success_sets_cookies(client):
+    register(client)
+    response = client.post(
+        "/api/auth/login", json={"username": "testuser", "password": "Password1"}
+    )
+    assert response.status_code == 200
+    assert "access_token" in response.cookies
+    assert "csrf_token" in response.cookies
+
+
+def test_login_wrong_password(client):
+    register(client)
+    response = client.post(
+        "/api/auth/login", json={"username": "testuser", "password": "WrongPass1"}
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "INVALID_CREDENTIALS"
+
+
+def test_login_nonexistent_user_same_error(client):
+    register(client)
+    wrong_password_response = client.post(
+        "/api/auth/login", json={"username": "testuser", "password": "WrongPass1"}
+    )
+    nonexistent_user_response = client.post(
+        "/api/auth/login", json={"username": "nouser", "password": "Password1"}
+    )
+    assert wrong_password_response.status_code == nonexistent_user_response.status_code == 401
+    assert (
+        wrong_password_response.json()["error"]["message"]
+        == nonexistent_user_response.json()["error"]["message"]
+    )
+
+
+def test_me_requires_authentication(client):
+    response = client.get("/api/auth/me")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "AUTHENTICATION_REQUIRED"
+
+
+def test_me_returns_current_user(client):
+    register(client)
+    client.post("/api/auth/login", json={"username": "testuser", "password": "Password1"})
+    response = client.get("/api/auth/me")
+    assert response.status_code == 200
+    assert response.json()["username"] == "testuser"
+
+
+def test_logout_requires_csrf_token(client):
+    register(client)
+    client.post("/api/auth/login", json={"username": "testuser", "password": "Password1"})
+    response = client.post("/api/auth/logout")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "CSRF_TOKEN_INVALID"
+
+
+def test_logout_with_csrf_token_clears_cookies(client):
+    register(client)
+    client.post("/api/auth/login", json={"username": "testuser", "password": "Password1"})
+    csrf_token = client.cookies.get("csrf_token")
+
+    response = client.post("/api/auth/logout", headers={"X-CSRF-Token": csrf_token})
+    assert response.status_code == 204
+
+    me_response = client.get("/api/auth/me")
+    assert me_response.status_code == 401
+
+
+def test_logout_with_mismatched_csrf_token_rejected(client):
+    register(client)
+    client.post("/api/auth/login", json={"username": "testuser", "password": "Password1"})
+
+    response = client.post("/api/auth/logout", headers={"X-CSRF-Token": "wrong-token"})
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "CSRF_TOKEN_INVALID"


### PR DESCRIPTION
## Summary
バックエンドの認証・認可基盤を実装。ユーザー登録・ログイン・ログアウト・ログインユーザー取得のAPIを提供する。

- `POST /api/auth/register` / `POST /api/auth/login` / `POST /api/auth/logout` / `GET /api/auth/me`
- JWT発行・検証（`core/security.py`）。HttpOnly Cookieに保存、`SameSite=Lax`、`Secure`属性は環境変数で切替可能、有効期限1時間
- CSRF対策：Double Submit Cookie方式。ログイン時にJS読み取り可能な`csrf_token` Cookieを発行し、状態変更系リクエストで`X-CSRF-Token`ヘッダーとCookie値を照合（`core/dependencies.py`の`verify_csrf_token`）
- 認可：`get_current_user`（ログイン必須）・`require_admin`（ADMIN必須）をDependencyとして実装。学習記録の所有者確認はPhase 4のService層に委譲する設計
- ログイン失敗時：ユーザー名の存在有無に関わらず`INVALID_CREDENTIALS`に統一（タイミング攻撃対策・レート制限は今回スコープ外）
- APIエラー共通形式（`{"error": {"code", "message", "details"}}`）の例外ハンドラ基盤を追加
- 新規エラーコード`CSRF_TOKEN_INVALID`(403)を追加（仕様書レビュー時に確認済み）

## フロントエンドについて
`/register`・`/login`画面は別Issueに分割して実装する（Issue番号は別途作成）。

## 実装中に確認した設計判断
- CSRF方式：Double Submit Cookie（ユーザー確認済み）
- 認可の実装場所：JWT検証・ログイン必須・ADMIN必須はDependency、所有者確認はService層（ユーザー確認済み）
- ログイン失敗時のエラー統一方式（ユーザー確認済み、タイミング対策なし）
- ユーザー名の使用可能文字種：半角英数字・ハイフン・アンダースコア（ユーザー確認済み）
- CSRF検証失敗のエラーコード：新規`CSRF_TOKEN_INVALID`を追加（ユーザー確認済み）

## Test plan
- [x] `POST /api/auth/register` 成功・重複ユーザー名エラー・パスワード不一致・パスワード強度不足を確認
- [x] `POST /api/auth/login` 成功時にHttpOnly `access_token` Cookieと非HttpOnly `csrf_token` Cookieが発行されることを確認
- [x] 存在しないユーザー名／パスワード間違いの両方で同一メッセージ・同一ステータスコードを確認
- [x] `GET /api/auth/me` が未ログイン時401、ログイン時にユーザー情報を返すことを確認
- [x] `POST /api/auth/logout` がCSRFトークンなしで403拒否、正しいトークンで204成功しCookieを削除することを確認
- [x] `pytest tests/test_auth.py` 12件すべて成功
- [x] `ruff check .` / `ruff format --check .` 通過

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)