### PR TITLE
Phase 3: Frontend認証画面（/register, /login, /dashboard）

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getCurrentUser, logout } from "@/lib/auth";
+import type { User } from "@/types/auth";
+
+export default function DashboardPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser().then((currentUser) => {
+      if (cancelled) return;
+      if (currentUser === null) {
+        router.push("/login");
+        return;
+      }
+      setUser(currentUser);
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  async function handleLogout() {
+    await logout();
+    router.push("/login");
+  }
+
+  if (loading || user === null) {
+    return null;
+  }
+
+  return (
+    <main>
+      <h1>ダッシュボード</h1>
+      <p>ようこそ、{user.username}さん</p>
+      <button type="button" onClick={handleLogout}>
+        ログアウト
+      </button>
+    </main>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { login } from "@/lib/auth";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+    setSubmitting(true);
+
+    try {
+      await login({ username, password });
+      router.push("/dashboard");
+    } catch (error) {
+      if (error instanceof ApiError) {
+        setFormError(error.message);
+      } else {
+        setFormError("ログインに失敗しました。しばらくしてから再度お試しください。");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main>
+      <h1>ログイン</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="username">ユーザー名</label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+
+        {formError && <p role="alert">{formError}</p>}
+
+        <button type="submit" disabled={submitting}>
+          ログイン
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { register } from "@/lib/auth";
+
+const USERNAME_PATTERN = /^[A-Za-z0-9_-]{1,25}$/;
+
+function validateUsername(username: string): string | null {
+  if (!USERNAME_PATTERN.test(username)) {
+    return "ユーザー名は1〜25文字の半角英数字・ハイフン・アンダースコアで入力してください";
+  }
+  return null;
+}
+
+function validatePassword(password: string): string | null {
+  if (password.length < 1 || password.length > 50) {
+    return "パスワードは50文字以内で入力してください";
+  }
+  if (!/[a-z]/.test(password)) {
+    return "パスワードは小文字を1文字以上含めてください";
+  }
+  if (!/[A-Z]/.test(password)) {
+    return "パスワードは大文字を1文字以上含めてください";
+  }
+  if (!/[0-9]/.test(password)) {
+    return "パスワードは数字を1文字以上含めてください";
+  }
+  return null;
+}
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  function validate(): boolean {
+    const errors: Record<string, string> = {};
+
+    const usernameError = validateUsername(username);
+    if (usernameError) errors.username = usernameError;
+
+    const passwordError = validatePassword(password);
+    if (passwordError) errors.password = passwordError;
+
+    if (password !== passwordConfirmation) {
+      errors.password_confirmation = "パスワードが一致しません";
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    if (!validate()) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await register({
+        username,
+        password,
+        password_confirmation: passwordConfirmation,
+      });
+      router.push("/login");
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.details) {
+          setFieldErrors(error.details);
+        }
+        setFormError(error.message);
+      } else {
+        setFormError("登録に失敗しました。しばらくしてから再度お試しください。");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main>
+      <h1>ユーザー登録</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="username">ユーザー名</label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          {fieldErrors.username && <p role="alert">{fieldErrors.username}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          {fieldErrors.password && <p role="alert">{fieldErrors.password}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="password_confirmation">パスワード確認</label>
+          <input
+            id="password_confirmation"
+            type="password"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+          />
+          {fieldErrors.password_confirmation && (
+            <p role="alert">{fieldErrors.password_confirmation}</p>
+          )}
+        </div>
+
+        {formError && <p role="alert">{formError}</p>}
+
+        <button type="submit" disabled={submitting}>
+          登録する
+        </button>
+      </form>
+      <a href="/login">ログインはこちら</a>
+    </main>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,18 +1,45 @@
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
 
-export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+export class ApiError extends Error {
+  code: string;
+  details?: Record<string, string>;
+
+  constructor(code: string, message: string, details?: Record<string, string>) {
+    super(message);
+    this.name = "ApiError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+interface ApiFetchOptions extends RequestInit {
+  csrfToken?: string;
+}
+
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const { csrfToken, headers, ...rest } = options;
+
   const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...options,
+    ...rest,
     credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      ...options.headers,
+      ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+      ...headers,
     },
   });
 
   if (!response.ok) {
     const body = await response.json().catch(() => null);
-    throw new Error(body?.error?.message ?? `Request failed with status ${response.status}`);
+    throw new ApiError(
+      body?.error?.code ?? "UNKNOWN_ERROR",
+      body?.error?.message ?? `Request failed with status ${response.status}`,
+      body?.error?.details,
+    );
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
   }
 
   return response.json() as Promise<T>;

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,0 +1,43 @@
+import { apiFetch } from "@/lib/api";
+import type { LoginRequest, RegisterRequest, User } from "@/types/auth";
+
+const CSRF_COOKIE_NAME = "csrf_token";
+
+function getCsrfTokenFromCookie(): string | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${CSRF_COOKIE_NAME}=([^;]*)`),
+  );
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+export function register(payload: RegisterRequest): Promise<User> {
+  return apiFetch<User>("/api/auth/register", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function login(payload: LoginRequest): Promise<User> {
+  return apiFetch<User>("/api/auth/login", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function logout(): Promise<void> {
+  return apiFetch<void>("/api/auth/logout", {
+    method: "POST",
+    csrfToken: getCsrfTokenFromCookie(),
+  });
+}
+
+export async function getCurrentUser(): Promise<User | null> {
+  try {
+    return await apiFetch<User>("/api/auth/me");
+  } catch {
+    return null;
+  }
+}

--- a/frontend/types/auth.ts
+++ b/frontend/types/auth.ts
@@ -1,0 +1,18 @@
+export type Role = "USER" | "ADMIN";
+
+export interface User {
+  id: number;
+  username: string;
+  role: Role;
+}
+
+export interface RegisterRequest {
+  username: string;
+  password: string;
+  password_confirmation: string;
+}
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}


### PR DESCRIPTION
## Summary
Backend認証API（Issue #4, PR #5）と接続する`/register`・`/login`画面、および認証状態確認付きの`/dashboard`プレースホルダーを実装。

- `lib/auth.ts`（新規）：`register`/`login`/`logout`/`getCurrentUser`。`logout`はCSRFトークンを`csrf_token` Cookie（非HttpOnly）から読み取り`X-CSRF-Token`ヘッダーに付与
- `lib/api.ts`（拡張）：`ApiError`クラス追加（`code`/`details`保持）。`csrfToken`オプションでヘッダー自動付与。204レスポンスにも対応
- `app/register/page.tsx`：クライアント側バリデーション（ユーザー名文字種・パスワード強度・確認一致）＋フィールド単位のエラー表示。成功時`/login`へ遷移
- `app/login/page.tsx`：ログインフォーム。成功時`/dashboard`へ遷移
- `app/dashboard/page.tsx`：マウント時に`GET /api/auth/me`で認証確認、未認証なら`/login`へリダイレクト

## 設計方針（事前確認・確定済み）
- 未認証時の保護ページ制御：Client Componentで`/me`を呼んで判定（Middlewareでの簡易チェックは行わない。認証・認可の最終判断はBackendに一本化）
- APIエラー表現：`ApiError`カスタムErrorクラス（既存`apiFetch`の「例外を投げる」設計を維持）

## 既存仕様の遵守
- JWTはHttpOnly Cookieのまま、Frontendから一切読み取り・操作しない
- `csrf_token`のみJavaScriptから読み取る（Double Submit Cookie方式）
- API通信は`lib/api.ts`経由、認証固有処理は`lib/auth.ts`に分離
- Frontendからroleを送信しない（登録リクエストにrole項目なし）

## Test plan
- [x] `npm run lint` 通過
- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 成功（`/`, `/login`, `/register`, `/dashboard`すべて生成）
- [x] Docker Compose全体起動確認（frontend:3000, backend:8000, db:3306）
- [x] E2E動作確認（curl）：登録→ログイン→Cookie発行確認→`/me`→CSRF付きログアウト→ログアウト後`/me`が401になることを確認
- [x] Backend側`pytest tests/test_auth.py` 12件が引き続き成功（回帰なし）

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)