### PR TITLE
Phase 5: カテゴリ管理API

### DIFF
--- a/backend/app/api/categories.py
+++ b/backend/app/api/categories.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.dependencies import get_current_user, require_admin, verify_csrf_token
+from app.db.database import get_db
+from app.models.user import User
+from app.schemas.category import CategoryRequest, CategoryResponse
+from app.services import category_service
+
+router = APIRouter(prefix="/api/categories", tags=["categories"])
+
+
+@router.get("", response_model=list[CategoryResponse])
+def list_categories(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[CategoryResponse]:
+    return category_service.list_categories(db)
+
+
+@router.post(
+    "",
+    response_model=CategoryResponse,
+    status_code=201,
+    dependencies=[Depends(verify_csrf_token)],
+)
+def create_category(
+    payload: CategoryRequest,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> CategoryResponse:
+    return category_service.create_category(db, name=payload.name)
+
+
+@router.put(
+    "/{category_id}",
+    response_model=CategoryResponse,
+    dependencies=[Depends(verify_csrf_token)],
+)
+def update_category(
+    category_id: int,
+    payload: CategoryRequest,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> CategoryResponse:
+    return category_service.update_category(db, category_id=category_id, name=payload.name)
+
+
+@router.delete(
+    "/{category_id}",
+    status_code=204,
+    dependencies=[Depends(verify_csrf_token)],
+)
+def delete_category(
+    category_id: int,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    category_service.delete_category(db, category_id=category_id)

--- a/backend/app/exceptions/exceptions.py
+++ b/backend/app/exceptions/exceptions.py
@@ -58,6 +58,11 @@ class UsernameAlreadyExistsError(AppError):
     code = "USERNAME_ALREADY_EXISTS"
 
 
+class CategoryAlreadyExistsError(AppError):
+    status_code = 409
+    code = "CATEGORY_ALREADY_EXISTS"
+
+
 class ValidationError(AppError):
     status_code = 422
     code = "VALIDATION_ERROR"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.auth import router as auth_router
+from app.api.categories import router as categories_router
 from app.api.study_records import router as study_records_router
 from app.core.config import settings
 from app.exceptions.handlers import register_exception_handlers
@@ -20,6 +21,7 @@ register_exception_handlers(app)
 
 app.include_router(auth_router)
 app.include_router(study_records_router)
+app.include_router(categories_router)
 
 
 @app.get("/health")

--- a/backend/app/repositories/category_repository.py
+++ b/backend/app/repositories/category_repository.py
@@ -15,3 +15,31 @@ def get_active_by_id(db: Session, category_id: int) -> Category | None:
         .filter(Category.id == category_id, Category.is_deleted.is_(False))
         .first()
     )
+
+
+def get_active_by_name(db: Session, name: str) -> Category | None:
+    return db.query(Category).filter(Category.name == name, Category.is_deleted.is_(False)).first()
+
+
+def list_active(db: Session) -> list[Category]:
+    return db.query(Category).filter(Category.is_deleted.is_(False)).order_by(Category.id).all()
+
+
+def create(db: Session, *, name: str) -> Category:
+    category = Category(name=name, is_deleted=False)
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+def update(db: Session, category: Category, *, name: str) -> Category:
+    category.name = name
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+def soft_delete(db: Session, category: Category) -> None:
+    category.is_deleted = True
+    db.commit()

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class CategoryRequest(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if not (1 <= len(value) <= 50):
+            raise ValueError("カテゴリ名は1〜50文字で入力してください")
+        return value
+
+
+class CategoryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.exceptions.exceptions import CategoryAlreadyExistsError, CategoryNotFoundError
+from app.models.category import Category
+from app.repositories import category_repository
+
+
+def list_categories(db: Session) -> list[Category]:
+    return category_repository.list_active(db)
+
+
+def create_category(db: Session, *, name: str) -> Category:
+    existing = category_repository.get_active_by_name(db, name)
+    if existing is not None:
+        raise CategoryAlreadyExistsError("このカテゴリ名は既に使用されています")
+    return category_repository.create(db, name=name)
+
+
+def update_category(db: Session, *, category_id: int, name: str) -> Category:
+    category = category_repository.get_active_by_id(db, category_id)
+    if category is None:
+        raise CategoryNotFoundError("指定されたカテゴリが見つかりません")
+
+    existing = category_repository.get_active_by_name(db, name)
+    if existing is not None and existing.id != category_id:
+        raise CategoryAlreadyExistsError("このカテゴリ名は既に使用されています")
+
+    return category_repository.update(db, category, name=name)
+
+
+def delete_category(db: Session, *, category_id: int) -> None:
+    category = category_repository.get_active_by_id(db, category_id)
+    if category is None:
+        raise CategoryNotFoundError("指定されたカテゴリが見つかりません")
+    category_repository.soft_delete(db, category)

--- a/backend/tests/test_categories.py
+++ b/backend/tests/test_categories.py
@@ -1,0 +1,280 @@
+from app.models.category import Category
+from app.models.user import User
+
+
+def register_and_login(client, username="user1", password="Password1"):
+    client.post(
+        "/api/auth/register",
+        json={
+            "username": username,
+            "password": password,
+            "password_confirmation": password,
+        },
+    )
+    client.post("/api/auth/login", json={"username": username, "password": password})
+
+
+def promote_to_admin(db_session, username):
+    user = db_session.query(User).filter(User.username == username).first()
+    user.role = "ADMIN"
+    db_session.commit()
+
+
+def register_and_login_as_admin(client, db_session, username="adminuser"):
+    register_and_login(client, username=username)
+    promote_to_admin(db_session, username)
+    client.post("/api/auth/logout", headers=csrf_headers(client))
+    client.post("/api/auth/login", json={"username": username, "password": "Password1"})
+
+
+def csrf_headers(client):
+    return {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+
+def create_category(db_session, name, is_deleted=False):
+    category = Category(name=name, is_deleted=is_deleted)
+    db_session.add(category)
+    db_session.commit()
+    db_session.refresh(category)
+    return category
+
+
+# --- 一覧 ---
+
+
+def test_list_categories_success(client, db_session):
+    register_and_login(client)
+    create_category(db_session, "TestCatAlpha")
+    create_category(db_session, "TestCatBeta")
+
+    response = client.get("/api/categories")
+    assert response.status_code == 200
+    names = {c["name"] for c in response.json()}
+    assert {"TestCatAlpha", "TestCatBeta"} <= names
+
+
+def test_list_categories_excludes_deleted(client, db_session):
+    register_and_login(client)
+    create_category(db_session, "Active")
+    create_category(db_session, "Deleted", is_deleted=True)
+
+    response = client.get("/api/categories")
+    names = {c["name"] for c in response.json()}
+    assert names == {"Active"}
+
+
+def test_list_categories_requires_authentication(client, db_session):
+    response = client.get("/api/categories")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "AUTHENTICATION_REQUIRED"
+
+
+def test_list_categories_allowed_for_user_role(client, db_session):
+    register_and_login(client)
+    create_category(db_session, "TestCatGamma")
+    response = client.get("/api/categories")
+    assert response.status_code == 200
+
+
+# --- 追加 ---
+
+
+def test_create_category_success_as_admin(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    response = client.post("/api/categories", json={"name": "Rust"}, headers=csrf_headers(client))
+    assert response.status_code == 201
+    assert response.json()["name"] == "Rust"
+
+
+def test_create_category_forbidden_for_user(client, db_session):
+    register_and_login(client)
+    response = client.post("/api/categories", json={"name": "Rust"}, headers=csrf_headers(client))
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ADMIN_REQUIRED"
+
+
+def test_create_category_requires_authentication(client, db_session):
+    response = client.post("/api/categories", json={"name": "Rust"})
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "AUTHENTICATION_REQUIRED"
+
+
+def test_create_category_requires_csrf(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    response = client.post("/api/categories", json={"name": "Rust"})
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "CSRF_TOKEN_INVALID"
+
+
+def test_create_category_duplicate_name_rejected(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    create_category(db_session, "Rust")
+    response = client.post("/api/categories", json={"name": "Rust"}, headers=csrf_headers(client))
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "CATEGORY_ALREADY_EXISTS"
+
+
+def test_create_category_same_name_as_deleted_allowed(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    create_category(db_session, "Rust", is_deleted=True)
+    response = client.post("/api/categories", json={"name": "Rust"}, headers=csrf_headers(client))
+    assert response.status_code == 201
+
+
+def test_create_category_name_too_long_rejected(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    response = client.post("/api/categories", json={"name": "a" * 51}, headers=csrf_headers(client))
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_create_category_empty_name_rejected(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    response = client.post("/api/categories", json={"name": ""}, headers=csrf_headers(client))
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_create_category_with_symbols_allowed(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    response = client.post(
+        "/api/categories", json={"name": "Next.js"}, headers=csrf_headers(client)
+    )
+    assert response.status_code == 201
+    assert response.json()["name"] == "Next.js"
+
+
+# --- 変更 ---
+
+
+def test_update_category_success(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "OldName")
+    response = client.put(
+        f"/api/categories/{category.id}",
+        json={"name": "NewName"},
+        headers=csrf_headers(client),
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "NewName"
+
+
+def test_update_category_forbidden_for_user(client, db_session):
+    register_and_login(client)
+    category = create_category(db_session, "OldName")
+    response = client.put(
+        f"/api/categories/{category.id}",
+        json={"name": "NewName"},
+        headers=csrf_headers(client),
+    )
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ADMIN_REQUIRED"
+
+
+def test_update_category_requires_csrf(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "OldName")
+    response = client.put(f"/api/categories/{category.id}", json={"name": "NewName"})
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "CSRF_TOKEN_INVALID"
+
+
+def test_update_category_not_found(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    response = client.put(
+        "/api/categories/999999", json={"name": "NewName"}, headers=csrf_headers(client)
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "CATEGORY_NOT_FOUND"
+
+
+def test_update_deleted_category_not_found(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "Deleted", is_deleted=True)
+    response = client.put(
+        f"/api/categories/{category.id}",
+        json={"name": "NewName"},
+        headers=csrf_headers(client),
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "CATEGORY_NOT_FOUND"
+
+
+def test_update_category_keeping_same_name_allowed(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "SameName")
+    response = client.put(
+        f"/api/categories/{category.id}",
+        json={"name": "SameName"},
+        headers=csrf_headers(client),
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "SameName"
+
+
+def test_update_category_to_duplicate_name_rejected(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    create_category(db_session, "Taken")
+    category = create_category(db_session, "Original")
+    response = client.put(
+        f"/api/categories/{category.id}", json={"name": "Taken"}, headers=csrf_headers(client)
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "CATEGORY_ALREADY_EXISTS"
+
+
+# --- 論理削除 ---
+
+
+def test_delete_category_success(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "ToDelete")
+    response = client.delete(f"/api/categories/{category.id}", headers=csrf_headers(client))
+    assert response.status_code == 204
+
+    list_response = client.get("/api/categories")
+    names = {c["name"] for c in list_response.json()}
+    assert "ToDelete" not in names
+
+
+def test_delete_category_forbidden_for_user(client, db_session):
+    register_and_login(client)
+    category = create_category(db_session, "ToDelete")
+    response = client.delete(f"/api/categories/{category.id}", headers=csrf_headers(client))
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ADMIN_REQUIRED"
+
+
+def test_delete_category_requires_csrf(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "ToDelete")
+    response = client.delete(f"/api/categories/{category.id}")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "CSRF_TOKEN_INVALID"
+
+
+def test_delete_category_not_found(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    response = client.delete("/api/categories/999999", headers=csrf_headers(client))
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "CATEGORY_NOT_FOUND"
+
+
+def test_delete_already_deleted_category_returns_404(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "ToDelete")
+    client.delete(f"/api/categories/{category.id}", headers=csrf_headers(client))
+    response = client.delete(f"/api/categories/{category.id}", headers=csrf_headers(client))
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "CATEGORY_NOT_FOUND"
+
+
+def test_delete_category_same_name_can_be_recreated(client, db_session):
+    register_and_login_as_admin(client, db_session)
+    category = create_category(db_session, "Recyclable")
+    client.delete(f"/api/categories/{category.id}", headers=csrf_headers(client))
+
+    response = client.post(
+        "/api/categories", json={"name": "Recyclable"}, headers=csrf_headers(client)
+    )
+    assert response.status_code == 201


### PR DESCRIPTION
## Summary
カテゴリの一覧・追加・変更・論理削除APIを実装。

- `GET /api/categories`（一覧：ログイン済みなら誰でも取得可）
- `POST /api/categories`（追加：ADMINのみ）
- `PUT /api/categories/{id}`（変更：ADMINのみ）
- `DELETE /api/categories/{id}`（論理削除：ADMINのみ）

## 確定した設計判断の実装
1. **一覧APIの対象範囲**：常に`is_deleted=FALSE`のカテゴリのみ返す
2. **カテゴリ名の文字種**：1〜50文字のみ制約とし文字種は制限しない（初期カテゴリに記号・スペースを含む名前が存在するため）
3. **編集時の重複チェック**：「同名かつ`is_deleted=FALSE`かつ`id != 自分自身`」で判定し、名前を変更しない編集を誤って拒否しない
4. **学習記録が紐づくカテゴリの削除**：紐づき有無に関わらず常に論理削除を許可

## 既存仕様の遵守
- Router → Service → Repository → Modelの責務分離を維持
- 認証：`get_current_user`、ADMIN判定：`require_admin`
- POST/PUT/DELETEに`verify_csrf_token`、GETには付けない
- カテゴリ名の重複判定はPhase 2で確定した`is_deleted=FALSE`内でのみ有効

## フロントエンドについて
`/admin/categories`画面は別Issue（#11）に分割して実装する。

## Test plan
`pytest tests/` **73件すべて成功**（既存auth 12件 + study_records 35件 + 新規categories 26件、回帰なし）

- [x] 一覧取得（USER/ADMINともに閲覧可、削除済みは除外）
- [x] 追加・変更・削除がADMINのみ許可され、USERは403 `ADMIN_REQUIRED`
- [x] CSRF検証（欠落時403 `CSRF_TOKEN_INVALID`）
- [x] 名前重複チェック（409 `CATEGORY_ALREADY_EXISTS`）、削除済み名との重複は許可
- [x] 編集時に名前を変更しない場合は重複エラーにならないことを確認
- [x] 存在しない/削除済みカテゴリへの操作（404 `CATEGORY_NOT_FOUND`）
- [x] 削除済みカテゴリ名の再利用（新規作成可能）
- [x] 記号・スペースを含むカテゴリ名（Next.js等）の受け入れ

`ruff check .` / `ruff format --check .` エラーなし

curlによる実機E2E確認：ADMIN追加→一覧反映→変更→論理削除→一覧から除外、USERによる追加試行が403で拒否されることを確認済み

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)