### PR TITLE
Phase 5: カテゴリ管理画面フロントエンド（/admin/categories）

### DIFF
--- a/frontend/app/admin/categories/page.tsx
+++ b/frontend/app/admin/categories/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { getCurrentUser } from "@/lib/auth";
+import { createCategory, deleteCategory, listCategories, updateCategory } from "@/lib/category";
+import type { Category } from "@/types/category";
+
+export default function AdminCategoriesPage() {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const [newName, setNewName] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [editError, setEditError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser().then((user) => {
+      if (cancelled) return;
+      if (user === null) {
+        router.push("/login");
+        return;
+      }
+      if (user.role !== "ADMIN") {
+        router.push("/dashboard");
+        return;
+      }
+      setAuthorized(true);
+      loadCategories();
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  async function loadCategories() {
+    try {
+      const data = await listCategories();
+      setCategories(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "カテゴリ一覧の取得に失敗しました。");
+    }
+  }
+
+  async function handleCreate(event: React.FormEvent) {
+    event.preventDefault();
+    setCreateError(null);
+    setCreating(true);
+    try {
+      await createCategory({ name: newName });
+      setNewName("");
+      await loadCategories();
+    } catch (e) {
+      setCreateError(e instanceof ApiError ? e.message : "カテゴリの追加に失敗しました。");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  function startEdit(category: Category) {
+    setEditingId(category.id);
+    setEditingName(category.name);
+    setEditError(null);
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditingName("");
+    setEditError(null);
+  }
+
+  async function handleSaveEdit(id: number) {
+    setEditError(null);
+    setSaving(true);
+    try {
+      await updateCategory(id, { name: editingName });
+      setEditingId(null);
+      setEditingName("");
+      await loadCategories();
+    } catch (e) {
+      setEditError(e instanceof ApiError ? e.message : "カテゴリの更新に失敗しました。");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(category: Category) {
+    if (!window.confirm(`カテゴリ「${category.name}」を削除しますか？`)) {
+      return;
+    }
+    try {
+      await deleteCategory(category.id);
+      await loadCategories();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "カテゴリの削除に失敗しました。");
+    }
+  }
+
+  if (!authorized) {
+    return null;
+  }
+
+  return (
+    <main>
+      <h1>カテゴリ管理</h1>
+
+      {error && <p role="alert">{error}</p>}
+
+      <form onSubmit={handleCreate}>
+        <label htmlFor="new-category-name">カテゴリ名</label>
+        <input
+          id="new-category-name"
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+        />
+        <button type="submit" disabled={creating}>
+          追加する
+        </button>
+        {createError && <p role="alert">{createError}</p>}
+      </form>
+
+      <table>
+        <thead>
+          <tr>
+            <th>カテゴリ名</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {categories.map((category) => (
+            <tr key={category.id}>
+              {editingId === category.id ? (
+                <>
+                  <td>
+                    <input
+                      type="text"
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                    />
+                    {editError && <p role="alert">{editError}</p>}
+                  </td>
+                  <td>
+                    <button
+                      type="button"
+                      onClick={() => handleSaveEdit(category.id)}
+                      disabled={saving}
+                    >
+                      保存
+                    </button>
+                    <button type="button" onClick={cancelEdit}>
+                      キャンセル
+                    </button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td>{category.name}</td>
+                  <td>
+                    <button type="button" onClick={() => startEdit(category)}>
+                      編集
+                    </button>
+                    <button type="button" onClick={() => handleDelete(category)}>
+                      削除
+                    </button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,5 @@
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+const CSRF_COOKIE_NAME = "csrf_token";
 
 export class ApiError extends Error {
   code: string;
@@ -10,6 +11,16 @@ export class ApiError extends Error {
     this.code = code;
     this.details = details;
   }
+}
+
+export function getCsrfTokenFromCookie(): string | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${CSRF_COOKIE_NAME}=([^;]*)`),
+  );
+  return match ? decodeURIComponent(match[1]) : undefined;
 }
 
 interface ApiFetchOptions extends RequestInit {

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,17 +1,5 @@
-import { apiFetch } from "@/lib/api";
+import { apiFetch, getCsrfTokenFromCookie } from "@/lib/api";
 import type { LoginRequest, RegisterRequest, User } from "@/types/auth";
-
-const CSRF_COOKIE_NAME = "csrf_token";
-
-function getCsrfTokenFromCookie(): string | undefined {
-  if (typeof document === "undefined") {
-    return undefined;
-  }
-  const match = document.cookie.match(
-    new RegExp(`(?:^|; )${CSRF_COOKIE_NAME}=([^;]*)`),
-  );
-  return match ? decodeURIComponent(match[1]) : undefined;
-}
 
 export function register(payload: RegisterRequest): Promise<User> {
   return apiFetch<User>("/api/auth/register", {

--- a/frontend/lib/category.ts
+++ b/frontend/lib/category.ts
@@ -1,0 +1,29 @@
+import { apiFetch, getCsrfTokenFromCookie } from "@/lib/api";
+import type { Category, CategoryRequest } from "@/types/category";
+
+export function listCategories(): Promise<Category[]> {
+  return apiFetch<Category[]>("/api/categories");
+}
+
+export function createCategory(payload: CategoryRequest): Promise<Category> {
+  return apiFetch<Category>("/api/categories", {
+    method: "POST",
+    body: JSON.stringify(payload),
+    csrfToken: getCsrfTokenFromCookie(),
+  });
+}
+
+export function updateCategory(id: number, payload: CategoryRequest): Promise<Category> {
+  return apiFetch<Category>(`/api/categories/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(payload),
+    csrfToken: getCsrfTokenFromCookie(),
+  });
+}
+
+export function deleteCategory(id: number): Promise<void> {
+  return apiFetch<void>(`/api/categories/${id}`, {
+    method: "DELETE",
+    csrfToken: getCsrfTokenFromCookie(),
+  });
+}

--- a/frontend/types/category.ts
+++ b/frontend/types/category.ts
@@ -1,0 +1,10 @@
+export interface Category {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CategoryRequest {
+  name: string;
+}


### PR DESCRIPTION
## Summary
Backendカテゴリ管理API（Issue #10, PR #12）と接続する`/admin/categories`画面を実装。

- `app/admin/categories/page.tsx`：一覧表示、追加フォーム、インライン編集、削除確認ダイアログ
- `lib/category.ts`：`listCategories`/`createCategory`/`updateCategory`/`deleteCategory`
- `lib/api.ts`：`getCsrfTokenFromCookie()`をexportし共通化
- `lib/auth.ts`：CSRFトークン取得を`lib/api.ts`からimportするよう変更（重複排除）

## 確定した設計判断の実装
1. **ADMIN権限チェック**：`getCurrentUser()`の`role`をページ側で確認。未認証は`/login`、USERは`/dashboard`へリダイレクト。Backend側の`require_admin`を最終防衛線として維持
2. **カテゴリ編集UI**：一覧行を編集モードに切り替えるインライン編集方式（編集専用ページ・モーダルは作成しない）
3. **CSRFトークン取得**：`getCsrfTokenFromCookie()`を`lib/api.ts`に移動・export。`lib/auth.ts`もこれを再利用

## 既存仕様の遵守
- API通信は`lib/api.ts`経由、画面から直接fetchしない
- 認証・認可の最終判断はBackendに一本化（Frontend側のADMIN判定はUI表示制御のみ）
- 削除前に確認ダイアログを表示（仕様書18節）
- Backend APIの仕様（Phase 5で確定済み）は無変更

## Test plan
- [x] `npm run lint` 通過
- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 成功（`/admin/categories`含む6ページすべて生成）
- [x] Docker Compose全体起動確認
- [x] Backend API E2E確認（curl）：ADMINでの一覧取得→追加→編集→論理削除→一覧反映を確認
- [x] USERロールでの`GET /api/auth/me`が`role: "USER"`を返すことを確認（Frontend側のリダイレクト判定に使う値）

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)