### PR TITLE
Phase 6: 学習記録 登録・編集・共通コンポーネント（Frontend）

### DIFF
--- a/frontend/app/study-records/[id]/edit/page.tsx
+++ b/frontend/app/study-records/[id]/edit/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import StudyRecordForm from "@/components/study-record/StudyRecordForm";
+import { ApiError } from "@/lib/api";
+import { getCurrentUser } from "@/lib/auth";
+import { getStudyRecord, updateStudyRecord } from "@/lib/study-record";
+import type { StudyRecordRequest } from "@/types/study-record";
+
+export default function EditStudyRecordPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const recordId = Number(params.id);
+
+  const [initialValues, setInitialValues] = useState<StudyRecordRequest | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser().then(async (user) => {
+      if (cancelled) return;
+      if (user === null) {
+        router.push("/login");
+        return;
+      }
+
+      try {
+        const record = await getStudyRecord(recordId);
+        if (cancelled) return;
+        setInitialValues({
+          category_id: record.category_id,
+          title: record.title,
+          content: record.content,
+          understanding_level: record.understanding_level,
+          study_minutes: record.study_minutes,
+          study_date: record.study_date,
+        });
+      } catch (e) {
+        if (cancelled) return;
+        setLoadError(
+          e instanceof ApiError ? e.message : "学習記録の取得に失敗しました。",
+        );
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router, recordId]);
+
+  async function handleSubmit(payload: StudyRecordRequest) {
+    await updateStudyRecord(recordId, payload);
+    router.push("/study-records");
+  }
+
+  function handleCancel() {
+    router.push("/study-records");
+  }
+
+  if (loadError) {
+    return (
+      <main>
+        <h1>学習記録編集</h1>
+        <p role="alert">{loadError}</p>
+      </main>
+    );
+  }
+
+  if (initialValues === null) {
+    return null;
+  }
+
+  return (
+    <main>
+      <h1>学習記録編集</h1>
+      <StudyRecordForm
+        initialValues={initialValues}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        submitLabel="更新する"
+      />
+    </main>
+  );
+}

--- a/frontend/app/study-records/new/page.tsx
+++ b/frontend/app/study-records/new/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import StudyRecordForm from "@/components/study-record/StudyRecordForm";
+import { getCurrentUser } from "@/lib/auth";
+import { createStudyRecord } from "@/lib/study-record";
+import type { StudyRecordRequest } from "@/types/study-record";
+
+export default function NewStudyRecordPage() {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser().then((user) => {
+      if (cancelled) return;
+      if (user === null) {
+        router.push("/login");
+        return;
+      }
+      setAuthorized(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  async function handleSubmit(payload: StudyRecordRequest) {
+    await createStudyRecord(payload);
+    router.push("/study-records");
+  }
+
+  function handleCancel() {
+    router.push("/study-records");
+  }
+
+  if (!authorized) {
+    return null;
+  }
+
+  return (
+    <main>
+      <h1>学習記録登録</h1>
+      <StudyRecordForm onSubmit={handleSubmit} onCancel={handleCancel} submitLabel="登録する" />
+    </main>
+  );
+}

--- a/frontend/components/study-record/StarRating.tsx
+++ b/frontend/components/study-record/StarRating.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface StarRatingProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const STAR_VALUES = [1, 2, 3, 4, 5];
+
+export default function StarRating({ value, onChange }: StarRatingProps) {
+  return (
+    <div role="radiogroup" aria-label="理解度">
+      {STAR_VALUES.map((star) => (
+        <button
+          key={star}
+          type="button"
+          role="radio"
+          aria-checked={value === star}
+          aria-label={`理解度${star}`}
+          onClick={() => onChange(star)}
+        >
+          {star <= value ? "★" : "☆"}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/study-record/StudyRecordForm.tsx
+++ b/frontend/components/study-record/StudyRecordForm.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import StarRating from "@/components/study-record/StarRating";
+import { ApiError } from "@/lib/api";
+import { listCategories } from "@/lib/category";
+import type { Category } from "@/types/category";
+import type { StudyRecordRequest } from "@/types/study-record";
+
+interface StudyRecordFormProps {
+  initialValues?: StudyRecordRequest;
+  onSubmit: (payload: StudyRecordRequest) => Promise<void>;
+  onCancel: () => void;
+  submitLabel: string;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function defaultValues(): StudyRecordRequest {
+  return {
+    category_id: 0,
+    title: "",
+    content: "",
+    understanding_level: 3,
+    study_minutes: 60,
+    study_date: today(),
+  };
+}
+
+function validateTitle(title: string): string | null {
+  if (title.length < 1 || title.length > 100) {
+    return "タイトルは1〜100文字で入力してください";
+  }
+  return null;
+}
+
+function validateContent(content: string): string | null {
+  if (content.length < 1) {
+    return "学習内容は1文字以上で入力してください";
+  }
+  return null;
+}
+
+function validateStudyMinutes(studyMinutes: number): string | null {
+  if (!Number.isInteger(studyMinutes) || studyMinutes < 1 || studyMinutes > 1440) {
+    return "学習時間は1〜1440分で入力してください";
+  }
+  return null;
+}
+
+function validateStudyDate(studyDate: string): string | null {
+  if (studyDate > today()) {
+    return "学習日には今日以前の日付を指定してください";
+  }
+  return null;
+}
+
+function validateCategoryId(categoryId: number): string | null {
+  if (!categoryId) {
+    return "カテゴリを選択してください";
+  }
+  return null;
+}
+
+export default function StudyRecordForm({
+  initialValues,
+  onSubmit,
+  onCancel,
+  submitLabel,
+}: StudyRecordFormProps) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [categoriesError, setCategoriesError] = useState<string | null>(null);
+
+  const [values, setValues] = useState<StudyRecordRequest>(initialValues ?? defaultValues());
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    listCategories()
+      .then(setCategories)
+      .catch((e) => {
+        setCategoriesError(
+          e instanceof ApiError ? e.message : "カテゴリ一覧の取得に失敗しました。",
+        );
+      });
+  }, []);
+
+  function validate(): boolean {
+    const errors: Record<string, string> = {};
+
+    const categoryIdError = validateCategoryId(values.category_id);
+    if (categoryIdError) errors.category_id = categoryIdError;
+
+    const titleError = validateTitle(values.title);
+    if (titleError) errors.title = titleError;
+
+    const contentError = validateContent(values.content);
+    if (contentError) errors.content = contentError;
+
+    const studyMinutesError = validateStudyMinutes(values.study_minutes);
+    if (studyMinutesError) errors.study_minutes = studyMinutesError;
+
+    const studyDateError = validateStudyDate(values.study_date);
+    if (studyDateError) errors.study_date = studyDateError;
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    if (!validate()) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await onSubmit(values);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        if (e.details) {
+          setFieldErrors(e.details);
+        }
+        setFormError(e.message);
+      } else {
+        setFormError("保存に失敗しました。しばらくしてから再度お試しください。");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {categoriesError && <p role="alert">{categoriesError}</p>}
+
+      <div>
+        <label htmlFor="category_id">カテゴリ</label>
+        <select
+          id="category_id"
+          value={values.category_id}
+          onChange={(e) => setValues({ ...values, category_id: Number(e.target.value) })}
+        >
+          <option value={0}>選択してください</option>
+          {categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+        {fieldErrors.category_id && <p role="alert">{fieldErrors.category_id}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="title">タイトル</label>
+        <input
+          id="title"
+          type="text"
+          value={values.title}
+          onChange={(e) => setValues({ ...values, title: e.target.value })}
+        />
+        {fieldErrors.title && <p role="alert">{fieldErrors.title}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="content">学習内容</label>
+        <textarea
+          id="content"
+          value={values.content}
+          onChange={(e) => setValues({ ...values, content: e.target.value })}
+        />
+        {fieldErrors.content && <p role="alert">{fieldErrors.content}</p>}
+      </div>
+
+      <div>
+        <span>理解度</span>
+        <StarRating
+          value={values.understanding_level}
+          onChange={(level) => setValues({ ...values, understanding_level: level })}
+        />
+        {fieldErrors.understanding_level && <p role="alert">{fieldErrors.understanding_level}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="study_minutes">学習時間（分）</label>
+        <input
+          id="study_minutes"
+          type="number"
+          value={values.study_minutes}
+          onChange={(e) => setValues({ ...values, study_minutes: Number(e.target.value) })}
+        />
+        {fieldErrors.study_minutes && <p role="alert">{fieldErrors.study_minutes}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="study_date">学習日</label>
+        <input
+          id="study_date"
+          type="date"
+          value={values.study_date}
+          max={today()}
+          onChange={(e) => setValues({ ...values, study_date: e.target.value })}
+        />
+        {fieldErrors.study_date && <p role="alert">{fieldErrors.study_date}</p>}
+      </div>
+
+      {formError && <p role="alert">{formError}</p>}
+
+      <button type="submit" disabled={submitting}>
+        {submitLabel}
+      </button>
+      <button type="button" onClick={onCancel}>
+        キャンセル
+      </button>
+    </form>
+  );
+}

--- a/frontend/lib/study-record.ts
+++ b/frontend/lib/study-record.ts
@@ -1,0 +1,25 @@
+import { apiFetch, getCsrfTokenFromCookie } from "@/lib/api";
+import type { StudyRecord, StudyRecordRequest } from "@/types/study-record";
+
+export function getStudyRecord(id: number): Promise<StudyRecord> {
+  return apiFetch<StudyRecord>(`/api/study-records/${id}`);
+}
+
+export function createStudyRecord(payload: StudyRecordRequest): Promise<StudyRecord> {
+  return apiFetch<StudyRecord>("/api/study-records", {
+    method: "POST",
+    body: JSON.stringify(payload),
+    csrfToken: getCsrfTokenFromCookie(),
+  });
+}
+
+export function updateStudyRecord(
+  id: number,
+  payload: StudyRecordRequest,
+): Promise<StudyRecord> {
+  return apiFetch<StudyRecord>(`/api/study-records/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(payload),
+    csrfToken: getCsrfTokenFromCookie(),
+  });
+}

--- a/frontend/types/study-record.ts
+++ b/frontend/types/study-record.ts
@@ -1,0 +1,29 @@
+export interface StudyRecord {
+  id: number;
+  category_id: number;
+  category_name: string;
+  title: string;
+  content: string;
+  understanding_level: number;
+  study_minutes: number;
+  study_date: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StudyRecordRequest {
+  category_id: number;
+  title: string;
+  content: string;
+  understanding_level: number;
+  study_minutes: number;
+  study_date: string;
+}
+
+export interface StudyRecordListResponse {
+  items: StudyRecord[];
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+}


### PR DESCRIPTION
## Summary
Backend学習記録CRUD API（Phase 4）と接続する登録・編集画面、および共通コンポーネントを実装。

- `components/study-record/StarRating.tsx`：理解度の星評価UI（☆☆☆☆☆クリック選択）
- `components/study-record/StudyRecordForm.tsx`：登録・編集で共有するフォーム本体。クライアント側バリデーション実施
- `app/study-records/new/page.tsx`：登録画面
- `app/study-records/[id]/edit/page.tsx`：編集画面（詳細表示を兼ねる）
- `lib/study-record.ts`：`getStudyRecord`/`createStudyRecord`/`updateStudyRecord`
- `types/study-record.ts`：型定義

## 確定した設計判断の実装
1. **詳細専用画面は作らない**：仕様書10節に定義がないため、`/study-records/[id]/edit`が詳細表示と編集を兼ねる
2. **共通コンポーネント新設**：仕様書26節の構成に従い`components/study-record/`配下にフォーム・星評価を作成し、登録・編集で共有
3. **Issue分割**：本Issue（登録・編集）→ Issue B（一覧・検索・削除）の順で進める

## 既存Frontend実装との整合
- API通信は`lib/api.ts`の`apiFetch`経由
- エラー表示は`ApiError`の`code`/`details`を利用（`/register`と同一パターン）
- CSRFトークンは`getCsrfTokenFromCookie()`
- 認証チェックは`getCurrentUser()`（学習記録操作はUSER/ADMIN共通、ADMIN限定分岐なし）

## スコープ外（Issue Bで対応）
一覧画面、検索・絞り込み、ページネーション、削除機能

## Test plan
- [x] `npm run lint` 通過
- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 成功（`/study-records/new`, `/study-records/[id]/edit`含む9ページ生成）
- [x] Backend API E2E確認（curl）：
  - 登録（`POST`、CSRF付き）→ 201、レスポンス形式が`StudyRecord`型と一致
  - 詳細取得（編集画面の初期値取得相当）→ 200
  - 更新（`PUT`、CSRF付き）→ 200、`updated_at`更新確認
  - 他ユーザーの記録への詳細アクセス → 403 `STUDY_RECORD_FORBIDDEN`（編集画面のエラー表示ロジックで正しくハンドリングされる形式であることを確認）
  - 存在しないIDへのアクセス → 404 `STUDY_RECORD_NOT_FOUND`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)