### PR TITLE
Phase 6: 学習記録 一覧・検索・削除（Frontend）

### DIFF
--- a/frontend/app/study-records/page.tsx
+++ b/frontend/app/study-records/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Pagination from "@/components/common/Pagination";
+import SearchForm from "@/components/study-record/SearchForm";
+import { ApiError } from "@/lib/api";
+import { getCurrentUser } from "@/lib/auth";
+import {
+  deleteStudyRecord,
+  listStudyRecords,
+  type StudyRecordSearchParams,
+} from "@/lib/study-record";
+import type { StudyRecord } from "@/types/study-record";
+
+function understandingLevelStars(level: number): string {
+  return "★".repeat(level) + "☆".repeat(5 - level);
+}
+
+export default function StudyRecordsPage() {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+
+  const [searchParams, setSearchParams] = useState<StudyRecordSearchParams>({});
+  const [page, setPage] = useState(1);
+
+  const [records, setRecords] = useState<StudyRecord[]>([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const [reloadCount, setReloadCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser().then((user) => {
+      if (cancelled) return;
+      if (user === null) {
+        router.push("/login");
+        return;
+      }
+      setAuthorized(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  useEffect(() => {
+    if (!authorized) {
+      return;
+    }
+
+    let cancelled = false;
+
+    listStudyRecords({ ...searchParams, page })
+      .then((result) => {
+        if (cancelled) return;
+        setRecords(result.items);
+        setTotalPages(result.total_pages);
+        setError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof ApiError ? e.message : "学習記録の取得に失敗しました。");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authorized, searchParams, page, reloadCount]);
+
+  function reload() {
+    setReloadCount((count) => count + 1);
+  }
+
+  function handleSearch(params: StudyRecordSearchParams) {
+    setSearchParams(params);
+    setPage(1);
+  }
+
+  async function handleDelete(record: StudyRecord) {
+    if (!window.confirm("この学習記録を削除しますか？")) {
+      return;
+    }
+    try {
+      await deleteStudyRecord(record.id);
+      reload();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "学習記録の削除に失敗しました。");
+    }
+  }
+
+  if (!authorized) {
+    return null;
+  }
+
+  return (
+    <main>
+      <h1>学習記録一覧</h1>
+
+      <a href="/study-records/new">学習記録を登録</a>
+
+      <SearchForm onSearch={handleSearch} />
+
+      {error && <p role="alert">{error}</p>}
+
+      <table>
+        <thead>
+          <tr>
+            <th>学習日</th>
+            <th>カテゴリ</th>
+            <th>タイトル</th>
+            <th>学習時間</th>
+            <th>理解度</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {records.map((record) => (
+            <tr key={record.id}>
+              <td>{record.study_date}</td>
+              <td>{record.category_name}</td>
+              <td>{record.title}</td>
+              <td>{record.study_minutes}分</td>
+              <td>{understandingLevelStars(record.understanding_level)}</td>
+              <td>
+                <a href={`/study-records/${record.id}/edit`}>編集</a>
+                <button type="button" onClick={() => handleDelete(record)}>
+                  削除
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+    </main>
+  );
+}

--- a/frontend/components/common/Pagination.tsx
+++ b/frontend/components/common/Pagination.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({ page, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="ページネーション">
+      <button type="button" disabled={page <= 1} onClick={() => onPageChange(page - 1)}>
+        前へ
+      </button>
+      <span>
+        {page} / {totalPages}
+      </span>
+      <button
+        type="button"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+      >
+        次へ
+      </button>
+    </nav>
+  );
+}

--- a/frontend/components/study-record/SearchForm.tsx
+++ b/frontend/components/study-record/SearchForm.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ApiError } from "@/lib/api";
+import { listCategories } from "@/lib/category";
+import type { Category } from "@/types/category";
+import type { StudyRecordSearchParams } from "@/lib/study-record";
+
+interface SearchFormProps {
+  onSearch: (params: StudyRecordSearchParams) => void;
+}
+
+const UNDERSTANDING_LEVELS = [1, 2, 3, 4, 5];
+
+export default function SearchForm({ onSearch }: SearchFormProps) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [categoriesError, setCategoriesError] = useState<string | null>(null);
+
+  const [keyword, setKeyword] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [understandingLevel, setUnderstandingLevel] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  useEffect(() => {
+    listCategories()
+      .then(setCategories)
+      .catch((e) => {
+        setCategoriesError(
+          e instanceof ApiError ? e.message : "カテゴリ一覧の取得に失敗しました。",
+        );
+      });
+  }, []);
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    onSearch({
+      keyword: keyword || undefined,
+      category_id: categoryId ? Number(categoryId) : undefined,
+      understanding_level: understandingLevel ? Number(understandingLevel) : undefined,
+      from: dateFrom || undefined,
+      to: dateTo || undefined,
+    });
+  }
+
+  function handleReset() {
+    setKeyword("");
+    setCategoryId("");
+    setUnderstandingLevel("");
+    setDateFrom("");
+    setDateTo("");
+    onSearch({});
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {categoriesError && <p role="alert">{categoriesError}</p>}
+
+      <div>
+        <label htmlFor="search-keyword">キーワード</label>
+        <input
+          id="search-keyword"
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="search-category">カテゴリ</label>
+        <select
+          id="search-category"
+          value={categoryId}
+          onChange={(e) => setCategoryId(e.target.value)}
+        >
+          <option value="">すべて</option>
+          {categories.map((category) => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="search-understanding-level">理解度</label>
+        <select
+          id="search-understanding-level"
+          value={understandingLevel}
+          onChange={(e) => setUnderstandingLevel(e.target.value)}
+        >
+          <option value="">すべて</option>
+          {UNDERSTANDING_LEVELS.map((level) => (
+            <option key={level} value={level}>
+              {level}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="search-date-from">学習日（開始）</label>
+        <input
+          id="search-date-from"
+          type="date"
+          value={dateFrom}
+          onChange={(e) => setDateFrom(e.target.value)}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="search-date-to">学習日（終了）</label>
+        <input
+          id="search-date-to"
+          type="date"
+          value={dateTo}
+          onChange={(e) => setDateTo(e.target.value)}
+        />
+      </div>
+
+      <button type="submit">検索</button>
+      <button type="button" onClick={handleReset}>
+        リセット
+      </button>
+    </form>
+  );
+}

--- a/frontend/lib/study-record.ts
+++ b/frontend/lib/study-record.ts
@@ -1,5 +1,34 @@
 import { apiFetch, getCsrfTokenFromCookie } from "@/lib/api";
-import type { StudyRecord, StudyRecordRequest } from "@/types/study-record";
+import type {
+  StudyRecord,
+  StudyRecordListResponse,
+  StudyRecordRequest,
+} from "@/types/study-record";
+
+export interface StudyRecordSearchParams {
+  keyword?: string;
+  category_id?: number;
+  understanding_level?: number;
+  from?: string;
+  to?: string;
+  page?: number;
+  page_size?: number;
+}
+
+export function listStudyRecords(
+  params: StudyRecordSearchParams = {},
+): Promise<StudyRecordListResponse> {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") {
+      query.set(key, String(value));
+    }
+  }
+  const queryString = query.toString();
+  return apiFetch<StudyRecordListResponse>(
+    `/api/study-records${queryString ? `?${queryString}` : ""}`,
+  );
+}
 
 export function getStudyRecord(id: number): Promise<StudyRecord> {
   return apiFetch<StudyRecord>(`/api/study-records/${id}`);
@@ -20,6 +49,13 @@ export function updateStudyRecord(
   return apiFetch<StudyRecord>(`/api/study-records/${id}`, {
     method: "PUT",
     body: JSON.stringify(payload),
+    csrfToken: getCsrfTokenFromCookie(),
+  });
+}
+
+export function deleteStudyRecord(id: number): Promise<void> {
+  return apiFetch<void>(`/api/study-records/${id}`, {
+    method: "DELETE",
     csrfToken: getCsrfTokenFromCookie(),
   });
 }


### PR DESCRIPTION
## Summary
Issue #14（登録・編集、PR #15でマージ済み）に続き、学習記録一覧・検索・絞り込み・ページネーション・削除を実装。

- `components/study-record/SearchForm.tsx`：キーワード・カテゴリ・理解度・学習期間の絞り込み
- `components/common/Pagination.tsx`：前へ/次へ形式のページネーション
- `app/study-records/page.tsx`：一覧画面（★☆形式の理解度表示、編集リンク、削除確認ダイアログ）
- `lib/study-record.ts`：`listStudyRecords`/`deleteStudyRecord`を追加

## 既存Frontend実装との整合（Issue #14で確立したパターンを踏襲）
- API通信は`lib/api.ts`の`apiFetch`経由
- エラー表示は`ApiError`の`code`/`details`を利用
- CSRFトークンは`getCsrfTokenFromCookie()`
- 認証チェックは`getCurrentUser()`

## 実装中に対応した点
ESLintの`react-hooks/set-state-in-effect`ルールにより、`useCallback`化したデータ取得関数を`useEffect`から呼び出すパターンがエラーとして検出されました。仕様に関わらない実装上の問題のため、フェッチ処理を`useEffect`内に直接インライン化し、リロードは依存配列に含めたカウンタ（`reloadCount`）をインクリメントする方式に変更して解消しています（Backend API・仕様への影響なし）。

## Test plan
- [x] `npm run lint` 通過
- [x] `npx tsc --noEmit` 通過
- [x] `npm run build` 成功（`/study-records`含む10ページ生成）
- [x] Backend API E2E確認（curl）：
  - 12件のテストデータ作成 → 一覧取得で`total: 12, total_pages: 2, items: 10`（1ページ目）、2ページ目`items: 2`を確認
  - キーワード検索（URLエンコード確認、`lib/study-record.ts`の`URLSearchParams`と同じ挙動）→ 期待通り1件ヒット
  - 削除（CSRF付き）→ 204、一覧件数が12→11に減少することを確認
- [x] フロントエンド`/study-records`ページの疎通確認（HTTP 200）

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)