### PR TITLE
Phase 7: 管理者機能API（Backend）

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.dependencies import require_admin
+from app.db.database import get_db
+from app.models.user import User
+from app.repositories import study_record_repository
+from app.schemas.study_record import StudyRecordListResponse, StudyRecordResponse
+from app.schemas.user import UserResponse
+from app.services import admin_service
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+@router.get("/users", response_model=list[UserResponse])
+def list_users(
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> list[UserResponse]:
+    return admin_service.list_users(db)
+
+
+@router.get("/users/{user_id}/study-records", response_model=StudyRecordListResponse)
+def list_user_study_records(
+    user_id: int,
+    keyword: str | None = None,
+    category_id: int | None = None,
+    understanding_level: int | None = None,
+    date_from: date | None = Query(None, alias="from"),
+    date_to: date | None = Query(None, alias="to"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, ge=1, le=100),
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> StudyRecordListResponse:
+    admin_service.get_user_or_404(db, user_id)
+
+    items, total = study_record_repository.search(
+        db,
+        user_id=user_id,
+        keyword=keyword,
+        category_id=category_id,
+        understanding_level=understanding_level,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        page_size=page_size,
+    )
+    total_pages = (total + page_size - 1) // page_size if total > 0 else 0
+    return StudyRecordListResponse(
+        items=[StudyRecordResponse.from_model(record) for record in items],
+        page=page,
+        page_size=page_size,
+        total=total,
+        total_pages=total_pages,
+    )

--- a/backend/app/exceptions/exceptions.py
+++ b/backend/app/exceptions/exceptions.py
@@ -48,6 +48,11 @@ class CategoryNotFoundError(AppError):
     code = "CATEGORY_NOT_FOUND"
 
 
+class UserNotFoundError(AppError):
+    status_code = 404
+    code = "USER_NOT_FOUND"
+
+
 class CsrfTokenInvalidError(AppError):
     status_code = 403
     code = "CSRF_TOKEN_INVALID"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.admin import router as admin_router
 from app.api.auth import router as auth_router
 from app.api.categories import router as categories_router
 from app.api.dashboard import router as dashboard_router
@@ -24,6 +25,7 @@ app.include_router(auth_router)
 app.include_router(study_records_router)
 app.include_router(categories_router)
 app.include_router(dashboard_router)
+app.include_router(admin_router)
 
 
 @app.get("/health")

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -13,6 +13,10 @@ def get_by_id(db: Session, user_id: int) -> User | None:
     return db.query(User).filter(User.id == user_id).first()
 
 
+def list_all(db: Session) -> list[User]:
+    return db.query(User).order_by(User.id).all()
+
+
 def create(db: Session, *, username: str, password_hash: str, role: str = "USER") -> User:
     user = User(username=username, password_hash=password_hash, role=role)
     db.add(user)

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.exceptions.exceptions import UserNotFoundError
+from app.models.user import User
+from app.repositories import user_repository
+
+
+def list_users(db: Session) -> list[User]:
+    return user_repository.list_all(db)
+
+
+def get_user_or_404(db: Session, user_id: int) -> User:
+    user = user_repository.get_by_id(db, user_id)
+    if user is None:
+        raise UserNotFoundError("指定されたユーザーが見つかりません")
+    return user

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,149 @@
+import itertools
+from datetime import date
+
+from app.models.category import Category
+from app.models.user import User
+
+_category_name_counter = itertools.count()
+
+
+def register_and_login(client, username="user1", password="Password1"):
+    client.post(
+        "/api/auth/register",
+        json={
+            "username": username,
+            "password": password,
+            "password_confirmation": password,
+        },
+    )
+    client.post("/api/auth/login", json={"username": username, "password": password})
+
+
+def promote_to_admin(db_session, username):
+    user = db_session.query(User).filter(User.username == username).first()
+    user.role = "ADMIN"
+    db_session.commit()
+
+
+def register_and_login_as_admin(client, db_session, username="adminuser"):
+    register_and_login(client, username=username)
+    promote_to_admin(db_session, username)
+    client.post("/api/auth/logout", headers=csrf_headers(client))
+    client.post("/api/auth/login", json={"username": username, "password": "Password1"})
+
+
+def csrf_headers(client):
+    return {"X-CSRF-Token": client.cookies.get("csrf_token")}
+
+
+def create_category(db_session, name=None, is_deleted=False):
+    if name is None:
+        name = f"TestCategory{next(_category_name_counter)}"
+    category = Category(name=name, is_deleted=is_deleted)
+    db_session.add(category)
+    db_session.commit()
+    db_session.refresh(category)
+    return category
+
+
+def valid_payload(category_id, **overrides):
+    payload = {
+        "category_id": category_id,
+        "title": "テストタイトル",
+        "content": "テスト内容",
+        "understanding_level": 3,
+        "study_minutes": 60,
+        "study_date": str(date.today()),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def create_record(client, db_session, **overrides):
+    category = create_category(db_session)
+    payload = valid_payload(category.id, **overrides)
+    response = client.post("/api/study-records", json=payload, headers=csrf_headers(client))
+    return response, category
+
+
+# --- ユーザー一覧 ---
+
+
+def test_list_users_success(client, db_session):
+    register_and_login(client, username="alice")
+    register_and_login_as_admin(client, db_session, username="adminuser")
+
+    response = client.get("/api/admin/users")
+    assert response.status_code == 200
+    usernames = {u["username"] for u in response.json()}
+    assert {"alice", "adminuser"} <= usernames
+
+
+def test_list_users_requires_authentication(client, db_session):
+    response = client.get("/api/admin/users")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "AUTHENTICATION_REQUIRED"
+
+
+def test_list_users_forbidden_for_non_admin(client, db_session):
+    register_and_login(client, username="bob")
+    response = client.get("/api/admin/users")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ADMIN_REQUIRED"
+
+
+# --- 他ユーザーの学習記録閲覧 ---
+
+
+def test_list_user_study_records_success(client, db_session):
+    register_and_login(client, username="owner")
+    response, _ = create_record(client, db_session)
+    assert response.status_code == 201
+    owner = db_session.query(User).filter(User.username == "owner").first()
+
+    register_and_login_as_admin(client, db_session, username="adminuser")
+    response = client.get(f"/api/admin/users/{owner.id}/study-records")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["title"] == "テストタイトル"
+
+
+def test_list_user_study_records_excludes_deleted(client, db_session):
+    register_and_login(client, username="owner")
+    response, _ = create_record(client, db_session)
+    record_id = response.json()["id"]
+    client.delete(f"/api/study-records/{record_id}", headers=csrf_headers(client))
+    owner = db_session.query(User).filter(User.username == "owner").first()
+
+    register_and_login_as_admin(client, db_session, username="adminuser")
+    response = client.get(f"/api/admin/users/{owner.id}/study-records")
+    assert response.json()["total"] == 0
+
+
+def test_list_user_study_records_forbidden_for_non_admin(client, db_session):
+    register_and_login(client, username="owner")
+    owner = db_session.query(User).filter(User.username == "owner").first()
+
+    register_and_login(client, username="bob")
+    response = client.get(f"/api/admin/users/{owner.id}/study-records")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ADMIN_REQUIRED"
+
+
+def test_list_user_study_records_nonexistent_user(client, db_session):
+    register_and_login_as_admin(client, db_session, username="adminuser")
+    response = client.get("/api/admin/users/999999/study-records")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "USER_NOT_FOUND"
+
+
+def test_list_user_study_records_admin_can_view_own_records(client, db_session):
+    register_and_login_as_admin(client, db_session, username="adminuser")
+    response, _ = create_record(client, db_session)
+    assert response.status_code == 201
+    admin = db_session.query(User).filter(User.username == "adminuser").first()
+
+    response = client.get(f"/api/admin/users/{admin.id}/study-records")
+    assert response.status_code == 200
+    assert response.json()["total"] == 1


### PR DESCRIPTION
## 概要
Issue #22 の実装。ADMINが全ユーザー一覧と、各ユーザーの学習記録を閲覧できるAPIを追加する。

## 変更内容
- `GET /api/admin/users`：全ユーザー一覧（ADMINのみ）
- `GET /api/admin/users/{id}/study-records`：指定ユーザーの学習記録一覧（ADMINのみ、閲覧専用）
- `app/repositories/user_repository.py`：`list_all` を追加
- `app/services/admin_service.py`：新規（ユーザー一覧取得・対象ユーザー存在確認）
- `app/exceptions/exceptions.py`：`UserNotFoundError`(404) を追加
- 学習記録の検索・レスポンス形式は既存の `/api/study-records` と同一（`study_record_repository.search` をそのまま流用）
- ADMIN自身のuser_idを指定した場合も特別扱いせず許可

## テスト
- `tests/test_admin.py` を新規追加（ユーザー一覧・学習記録閲覧の正常系・認可・404系）
- 全94件のpytestが通過
- Ruff（lint / format）通過

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)