### PR TITLE
Phase 7: 管理者機能画面（Frontend）

### DIFF
--- a/frontend/app/admin/users/[id]/study-records/page.tsx
+++ b/frontend/app/admin/users/[id]/study-records/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import SearchForm from "@/components/study-record/SearchForm";
+import Pagination from "@/components/common/Pagination";
+import { ApiError } from "@/lib/api";
+import { getCurrentUser } from "@/lib/auth";
+import { getUserStudyRecords, listUsers } from "@/lib/admin";
+import type { StudyRecordSearchParams } from "@/lib/study-record";
+import { understandingLevelStars } from "@/lib/understanding-level";
+import type { StudyRecord } from "@/types/study-record";
+import type { User } from "@/types/auth";
+
+export default function AdminUserStudyRecordsPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const userId = Number(params.id);
+
+  const [authorized, setAuthorized] = useState(false);
+  const [targetUser, setTargetUser] = useState<User | null>(null);
+
+  const [searchParams, setSearchParams] = useState<StudyRecordSearchParams>({});
+  const [page, setPage] = useState(1);
+
+  const [records, setRecords] = useState<StudyRecord[]>([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser().then((user) => {
+      if (cancelled) return;
+      if (user === null) {
+        router.push("/login");
+        return;
+      }
+      if (user.role !== "ADMIN") {
+        router.push("/dashboard");
+        return;
+      }
+      setAuthorized(true);
+
+      listUsers()
+        .then((users) => {
+          if (cancelled) return;
+          setTargetUser(users.find((u) => u.id === userId) ?? null);
+        })
+        .catch(() => {
+          /* ユーザー名表示は補助情報のため、失敗しても一覧の取得は継続する */
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router, userId]);
+
+  useEffect(() => {
+    if (!authorized) {
+      return;
+    }
+
+    let cancelled = false;
+
+    getUserStudyRecords(userId, { ...searchParams, page })
+      .then((result) => {
+        if (cancelled) return;
+        setRecords(result.items);
+        setTotalPages(result.total_pages);
+        setError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof ApiError ? e.message : "学習記録の取得に失敗しました。");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authorized, userId, searchParams, page]);
+
+  function handleSearch(params: StudyRecordSearchParams) {
+    setSearchParams(params);
+    setPage(1);
+  }
+
+  if (!authorized) {
+    return null;
+  }
+
+  return (
+    <main>
+      <h1>{targetUser ? `${targetUser.username} さんの学習記録` : "学習記録"}</h1>
+
+      <a href="/admin/users">ユーザー一覧に戻る</a>
+
+      <SearchForm onSearch={handleSearch} />
+
+      {error && <p role="alert">{error}</p>}
+
+      <table>
+        <thead>
+          <tr>
+            <th>学習日</th>
+            <th>カテゴリ</th>
+            <th>タイトル</th>
+            <th>学習時間</th>
+            <th>理解度</th>
+          </tr>
+        </thead>
+        <tbody>
+          {records.map((record) => (
+            <tr key={record.id}>
+              <td>{record.study_date}</td>
+              <td>{record.category_name}</td>
+              <td>{record.title}</td>
+              <td>{record.study_minutes}分</td>
+              <td>{understandingLevelStars(record.understanding_level)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+    </main>
+  );
+}

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiError } from "@/lib/api";
+import { getCurrentUser } from "@/lib/auth";
+import { listUsers } from "@/lib/admin";
+import type { User } from "@/types/auth";
+
+export default function AdminUsersPage() {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+  const [users, setUsers] = useState<User[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser().then((user) => {
+      if (cancelled) return;
+      if (user === null) {
+        router.push("/login");
+        return;
+      }
+      if (user.role !== "ADMIN") {
+        router.push("/dashboard");
+        return;
+      }
+      setAuthorized(true);
+
+      listUsers()
+        .then((data) => {
+          if (cancelled) return;
+          setUsers(data);
+        })
+        .catch((e) => {
+          if (cancelled) return;
+          setError(e instanceof ApiError ? e.message : "ユーザー一覧の取得に失敗しました。");
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  if (!authorized) {
+    return null;
+  }
+
+  return (
+    <main>
+      <h1>ユーザー一覧</h1>
+
+      {error && <p role="alert">{error}</p>}
+
+      <table>
+        <thead>
+          <tr>
+            <th>ユーザー名</th>
+            <th>権限</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user) => (
+            <tr key={user.id}>
+              <td>{user.username}</td>
+              <td>{user.role}</td>
+              <td>
+                <a href={`/admin/users/${user.id}/study-records`}>学習記録を見る</a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/frontend/lib/admin.ts
+++ b/frontend/lib/admin.ts
@@ -1,0 +1,24 @@
+import { apiFetch } from "@/lib/api";
+import type { StudyRecordListResponse } from "@/types/study-record";
+import type { StudyRecordSearchParams } from "@/lib/study-record";
+import type { User } from "@/types/auth";
+
+export function listUsers(): Promise<User[]> {
+  return apiFetch<User[]>("/api/admin/users");
+}
+
+export function getUserStudyRecords(
+  userId: number,
+  params: StudyRecordSearchParams = {},
+): Promise<StudyRecordListResponse> {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== "") {
+      query.set(key, String(value));
+    }
+  }
+  const queryString = query.toString();
+  return apiFetch<StudyRecordListResponse>(
+    `/api/admin/users/${userId}/study-records${queryString ? `?${queryString}` : ""}`,
+  );
+}


### PR DESCRIPTION
## 概要
Issue #23 の実装。ADMINがユーザー一覧と各ユーザーの学習記録を閲覧できる画面を追加する。Backend API（PR #24, マージ済み）に依存。

## 変更内容
- `frontend/lib/admin.ts`：`listUsers()` / `getUserStudyRecords(userId, params)`
- `frontend/app/admin/users/page.tsx`：ユーザー一覧画面（username / roleのみ表示、ページネーションなし）
- `frontend/app/admin/users/[id]/study-records/page.tsx`：対象ユーザーの学習記録閲覧画面（既存の検索フォーム・ページネーションを流用、閲覧専用で編集・削除ボタンなし）
- 認可チェックは`/admin/categories`と同じパターン（未認証は`/login`、ADMIN以外は`/dashboard`へリダイレクト）

## 動作確認
- `npm run lint` / `npx tsc --noEmit` / `npm run build` すべて通過
- Docker Composeでbackend/frontendを起動し、admin/一般ユーザーでの登録・ログイン・学習記録作成・管理者による閲覧をAPI経由でエンドツーエンド確認済み

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)