### PR TITLE
GitHub ActionsによるCI導入（PR時のBackend/Frontend自動チェック）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
 
       - run: npm ci
       - run: npm run lint
+      - run: npx next typegen
       - run: npx tsc --noEmit
       - run: npm run test
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: studylog
+          MYSQL_USER: studylog
+          MYSQL_PASSWORD: studylog
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -uroot -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+
+    defaults:
+      run:
+        working-directory: backend
+
+    env:
+      DATABASE_URL: mysql+pymysql://studylog:studylog@127.0.0.1:3306/studylog
+      JWT_SECRET_KEY: ci-test-secret
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/requirements*.txt
+
+      - run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: pytest tests/ -v
+
+  frontend:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm run test
+      - run: npm run build


### PR DESCRIPTION
## 概要
Issue #30 の実装。GitHub Actionsで `main` 向けPR作成・更新時にBackend/Frontendの品質チェックを自動実行するCIを導入する。

## 変更内容
`.github/workflows/ci.yml` を新規作成。1つのWorkflow内で `backend` / `frontend` の2ジョブを並列実行する。

### backend ジョブ
- MySQL 8.0を `services` で起動（docker-compose.ymlのDB設定と同一のユーザー名・パスワード・DB名）
- `actions/setup-python`（3.11、pipキャッシュ）
- `ruff check .` → `ruff format --check .` → `pytest tests/ -v`
- テストDBスキーマは既存の `conftest.py` の `Base.metadata.create_all()` をそのまま利用（`alembic upgrade head` は追加していない）

### frontend ジョブ
- `actions/setup-node`（Node 22、npmキャッシュ）
- `npm ci` → `npm run lint` → `npx next typegen` → `npx tsc --noEmit` → `npm run test` → `npm run build`

## 実装中に判明した問題と対応
初回のCI実行で `frontend` ジョブが `npx tsc --noEmit` で失敗した（`app/layout.tsx(20,50): error TS2304: Cannot find name 'LayoutProps'`）。

原因：Next.js 16は `LayoutProps` 等のルート型定義を `.next/types/` に自動生成するが、CIのクリーンな環境ではこれが未生成のまま `tsc --noEmit` を単体実行したため型解決に失敗した（ローカルでは既存の `.next` が残っていたため気づけなかった）。

対応：`npm run lint` の後・`npx tsc --noEmit` の前に `npx next typegen`（ビルドを行わずルート型定義のみ生成するNext.js公式コマンド）を追加し、tsc単体チェックの構成を維持したまま解決した。

## スコープ外（今回対応しない）
- Branch ProtectionのRequired Status Check設定
- pushトリガーの追加
- `alembic upgrade head` を用いたスキーマ検証

## CI実行結果
修正後、実際にPR上でGitHub Actionsを実行し、両ジョブの成功を確認済み。
- backend: pass（1m41s）
- frontend: pass（46s）

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)