### PR TITLE
Phase 9: Backend実装改善（レイヤー整合性・DBロールバック・学習日バリデーションのJST統一）

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import Session
 from app.core.dependencies import require_admin
 from app.db.database import get_db
 from app.models.user import User
-from app.repositories import study_record_repository
 from app.schemas.study_record import StudyRecordListResponse, StudyRecordResponse
 from app.schemas.user import UserResponse
 from app.services import admin_service
@@ -37,9 +36,7 @@ def list_user_study_records(
     current_user: User = Depends(require_admin),
     db: Session = Depends(get_db),
 ) -> StudyRecordListResponse:
-    admin_service.get_user_or_404(db, user_id)
-
-    items, total = study_record_repository.search(
+    items, total = admin_service.list_user_study_records(
         db,
         user_id=user_id,
         keyword=keyword,

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -17,5 +17,8 @@ def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:
         yield db
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()

--- a/backend/app/schemas/study_record.py
+++ b/backend/app/schemas/study_record.py
@@ -2,6 +2,8 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from app.core.clock import today_jst
+
 
 class StudyRecordRequest(BaseModel):
     category_id: int
@@ -42,7 +44,7 @@ class StudyRecordRequest(BaseModel):
     @field_validator("study_date")
     @classmethod
     def validate_study_date(cls, value: date) -> date:
-        if value > date.today():
+        if value > today_jst():
             raise ValueError("学習日には今日以前の日付を指定してください")
         return value
 

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from datetime import date
+
 from sqlalchemy.orm import Session
 
 from app.exceptions.exceptions import UserNotFoundError
+from app.models.study_record import StudyRecord
 from app.models.user import User
-from app.repositories import user_repository
+from app.repositories import study_record_repository, user_repository
 
 
 def list_users(db: Session) -> list[User]:
@@ -16,3 +19,29 @@ def get_user_or_404(db: Session, user_id: int) -> User:
     if user is None:
         raise UserNotFoundError("指定されたユーザーが見つかりません")
     return user
+
+
+def list_user_study_records(
+    db: Session,
+    *,
+    user_id: int,
+    keyword: str | None,
+    category_id: int | None,
+    understanding_level: int | None,
+    date_from: date | None,
+    date_to: date | None,
+    page: int,
+    page_size: int,
+) -> tuple[list[StudyRecord], int]:
+    get_user_or_404(db, user_id)
+    return study_record_repository.search(
+        db,
+        user_id=user_id,
+        keyword=keyword,
+        category_id=category_id,
+        understanding_level=understanding_level,
+        date_from=date_from,
+        date_to=date_to,
+        page=page,
+        page_size=page_size,
+    )

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,6 +1,6 @@
 import itertools
-from datetime import date
 
+from app.core.clock import today_jst
 from app.models.category import Category
 from app.models.user import User
 
@@ -53,7 +53,7 @@ def valid_payload(category_id, **overrides):
         "content": "テスト内容",
         "understanding_level": 3,
         "study_minutes": 60,
-        "study_date": str(date.today()),
+        "study_date": str(today_jst()),
     }
     payload.update(overrides)
     return payload

--- a/backend/tests/test_study_records.py
+++ b/backend/tests/test_study_records.py
@@ -1,6 +1,7 @@
 import itertools
-from datetime import date, timedelta
+from datetime import timedelta
 
+from app.core.clock import today_jst
 from app.models.category import Category
 
 _category_name_counter = itertools.count()
@@ -39,7 +40,7 @@ def valid_payload(category_id, **overrides):
         "content": "テスト内容",
         "understanding_level": 3,
         "study_minutes": 60,
-        "study_date": str(date.today()),
+        "study_date": str(today_jst()),
     }
     payload.update(overrides)
     return payload
@@ -164,7 +165,7 @@ def test_create_study_record_study_minutes_out_of_range(client, db_session):
 def test_create_study_record_future_study_date(client, db_session):
     register_and_login(client)
     category = create_category(db_session)
-    tomorrow = str(date.today() + timedelta(days=1))
+    tomorrow = str(today_jst() + timedelta(days=1))
     response = client.post(
         "/api/study-records",
         json=valid_payload(category.id, study_date=tomorrow),
@@ -484,7 +485,7 @@ def test_list_study_records_multiple_conditions_and(client, db_session):
 def test_list_study_records_date_range(client, db_session):
     register_and_login(client)
     category = create_category(db_session)
-    today = date.today()
+    today = today_jst()
     old_date = today - timedelta(days=10)
 
     client.post(


### PR DESCRIPTION
## 概要
Issue #32 の実装。Phase 9の総合レビューで見つかったBackend側の推奨対応3件を実施する。

## 変更内容

### 1. admin.pyのレイヤー整合性修正
`app/api/admin.py`の`list_user_study_records`だけがServiceを経由せず`study_record_repository`を直接呼んでおり、他エンドポイントのRouter→Service→Repositoryの規約から逸脱していた。`admin_service.py`に`list_user_study_records`（ユーザー存在確認＋検索を内包）を追加し、`admin.py`はこれを呼ぶだけに変更した。挙動は変えていない。

### 2. get_dbの例外時ロールバック追加
`app/db/database.py`の`get_db`が例外発生時に`db.rollback()`を呼ばずそのまま`close()`していた。将来複数ステップの書き込み処理が増えた際の保険として、例外時のロールバックを追加した。

### 3. 学習日バリデーションのJST統一（今回の主眼）

**変更前の問題**
`app/schemas/study_record.py`の`validate_study_date`が`date.today()`（サーバーのシステムタイムゾーンに依存する関数）を使って「未来日か」を判定していた。

**なぜUTC環境で問題になるのか**
`docker exec studylog-backend-1 date`で確認したところ、backendコンテナ・GitHub Actions CIランナーはいずれも**UTC**で動作している。JSTはUTC+9のため、日本時間15:00〜23:59の間はUTC側の日付がまだ「前日」を指している。この時間帯にJSTの「今日」の日付で学習記録を登録しようとすると、サーバー側が誤って「未来日」と判定し、本来通るべきリクエストが422 `VALIDATION_ERROR`で拒否されてしまう実害があった。

**today_jst()への統一内容**
`app/core/clock.py`に既存の`today_jst()`（`ZoneInfo("Asia/Tokyo")`を使い明示的にJST基準で「今日」を計算、`dashboard_service.py`で既に実績あり）に差し替えた。

**テストも同じ基準へ変更したこと**
`validate_study_date`だけを直すと、テスト側（`tests/test_study_records.py`・`tests/test_admin.py`）が引き続き`date.today()`でテストデータの日付を作っていたため、UTC基準で「今日」が変わる境界時刻（JST 0:00〜8:59）にCIが実行されると、テストが用意した「今日」の日付がバリデータ視点では未来日と判定され、テストデータの投入自体が失敗するflaky testになるリスクがあった。これを避けるため、`tests/test_study_records.py`・`tests/test_admin.py`双方の日付生成ロジックも`today_jst()`に統一し、バリデータとテストの基準を完全に揃えた。

## 動作確認
- `pytest tests/ -v` → 94件全て通過
- `ruff check .` / `ruff format --check .` → 通過

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)