### PR TITLE
Phase 9: APIエラー処理の共通化

### DIFF
--- a/frontend/app/(protected)/admin/categories/page.tsx
+++ b/frontend/app/(protected)/admin/categories/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import { createCategory, deleteCategory, listCategories, updateCategory } from "@/lib/category";
 import type { Category } from "@/types/category";
 
@@ -29,7 +29,7 @@ export default function AdminCategoriesPage() {
       setCategories(data);
       setError(null);
     } catch (e) {
-      setError(e instanceof ApiError ? e.message : "カテゴリ一覧の取得に失敗しました。");
+      setError(toErrorMessage(e, "カテゴリ一覧の取得に失敗しました。"));
     }
   }
 
@@ -42,7 +42,7 @@ export default function AdminCategoriesPage() {
       setNewName("");
       await loadCategories();
     } catch (e) {
-      setCreateError(e instanceof ApiError ? e.message : "カテゴリの追加に失敗しました。");
+      setCreateError(toErrorMessage(e, "カテゴリの追加に失敗しました。"));
     } finally {
       setCreating(false);
     }
@@ -69,7 +69,7 @@ export default function AdminCategoriesPage() {
       setEditingName("");
       await loadCategories();
     } catch (e) {
-      setEditError(e instanceof ApiError ? e.message : "カテゴリの更新に失敗しました。");
+      setEditError(toErrorMessage(e, "カテゴリの更新に失敗しました。"));
     } finally {
       setSaving(false);
     }
@@ -83,7 +83,7 @@ export default function AdminCategoriesPage() {
       await deleteCategory(category.id);
       await loadCategories();
     } catch (e) {
-      setError(e instanceof ApiError ? e.message : "カテゴリの削除に失敗しました。");
+      setError(toErrorMessage(e, "カテゴリの削除に失敗しました。"));
     }
   }
 

--- a/frontend/app/(protected)/admin/users/[id]/study-records/page.tsx
+++ b/frontend/app/(protected)/admin/users/[id]/study-records/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import SearchForm from "@/components/study-record/SearchForm";
 import Pagination from "@/components/common/Pagination";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import { getUserStudyRecords, listUsers } from "@/lib/admin";
 import type { StudyRecordSearchParams } from "@/lib/study-record";
 import { understandingLevelStars } from "@/lib/understanding-level";
@@ -55,7 +55,7 @@ export default function AdminUserStudyRecordsPage() {
       })
       .catch((e) => {
         if (cancelled) return;
-        setError(e instanceof ApiError ? e.message : "学習記録の取得に失敗しました。");
+        setError(toErrorMessage(e, "学習記録の取得に失敗しました。"));
       });
 
     return () => {

--- a/frontend/app/(protected)/admin/users/page.tsx
+++ b/frontend/app/(protected)/admin/users/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import { listUsers } from "@/lib/admin";
 import type { User } from "@/types/auth";
 
@@ -21,7 +21,7 @@ export default function AdminUsersPage() {
       })
       .catch((e) => {
         if (cancelled) return;
-        setError(e instanceof ApiError ? e.message : "ユーザー一覧の取得に失敗しました。");
+        setError(toErrorMessage(e, "ユーザー一覧の取得に失敗しました。"));
       });
 
     return () => {

--- a/frontend/app/(protected)/dashboard/page.tsx
+++ b/frontend/app/(protected)/dashboard/page.tsx
@@ -9,7 +9,7 @@ import RecentRecords from "@/components/dashboard/RecentRecords";
 import StreakCard from "@/components/dashboard/StreakCard";
 import TodayStudyTime from "@/components/dashboard/TodayStudyTime";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import { useAuthUser } from "@/lib/auth-context";
 import { getDashboard } from "@/lib/dashboard";
 import type { Dashboard } from "@/types/dashboard";
@@ -29,7 +29,7 @@ export default function DashboardPage() {
       })
       .catch((e) => {
         if (cancelled) return;
-        setError(e instanceof ApiError ? e.message : "ダッシュボードの取得に失敗しました。");
+        setError(toErrorMessage(e, "ダッシュボードの取得に失敗しました。"));
       });
 
     return () => {

--- a/frontend/app/(protected)/study-records/[id]/edit/page.tsx
+++ b/frontend/app/(protected)/study-records/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import StudyRecordForm from "@/components/study-record/StudyRecordForm";
 import ErrorMessage from "@/components/common/ErrorMessage";
 import Loading from "@/components/common/Loading";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import { getStudyRecord, updateStudyRecord } from "@/lib/study-record";
 import type { StudyRecordRequest } from "@/types/study-record";
 
@@ -34,7 +34,7 @@ export default function EditStudyRecordPage() {
       })
       .catch((e) => {
         if (cancelled) return;
-        setLoadError(e instanceof ApiError ? e.message : "学習記録の取得に失敗しました。");
+        setLoadError(toErrorMessage(e, "学習記録の取得に失敗しました。"));
       });
 
     return () => {

--- a/frontend/app/(protected)/study-records/page.tsx
+++ b/frontend/app/(protected)/study-records/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Pagination from "@/components/common/Pagination";
 import ErrorMessage from "@/components/common/ErrorMessage";
 import SearchForm from "@/components/study-record/SearchForm";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import {
   deleteStudyRecord,
   listStudyRecords,
@@ -36,7 +36,7 @@ export default function StudyRecordsPage() {
       })
       .catch((e) => {
         if (cancelled) return;
-        setError(e instanceof ApiError ? e.message : "学習記録の取得に失敗しました。");
+        setError(toErrorMessage(e, "学習記録の取得に失敗しました。"));
       });
 
     return () => {
@@ -61,7 +61,7 @@ export default function StudyRecordsPage() {
       await deleteStudyRecord(record.id);
       reload();
     } catch (e) {
-      setError(e instanceof ApiError ? e.message : "学習記録の削除に失敗しました。");
+      setError(toErrorMessage(e, "学習記録の削除に失敗しました。"));
     }
   }
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import { login } from "@/lib/auth";
 
 export default function LoginPage() {
@@ -22,11 +22,7 @@ export default function LoginPage() {
       await login({ username, password });
       router.replace("/dashboard");
     } catch (error) {
-      if (error instanceof ApiError) {
-        setFormError(error.message);
-      } else {
-        setFormError("ログインに失敗しました。しばらくしてから再度お試しください。");
-      }
+      setFormError(toErrorMessage(error, "ログインに失敗しました。しばらくしてから再度お試しください。"));
     } finally {
       setSubmitting(false);
     }

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { getErrorDetails, toErrorMessage } from "@/lib/api";
 import { register } from "@/lib/auth";
 
 const USERNAME_PATTERN = /^[A-Za-z0-9_-]{1,25}$/;
@@ -75,14 +75,11 @@ export default function RegisterPage() {
       });
       router.push("/login");
     } catch (error) {
-      if (error instanceof ApiError) {
-        if (error.details) {
-          setFieldErrors(error.details);
-        }
-        setFormError(error.message);
-      } else {
-        setFormError("登録に失敗しました。しばらくしてから再度お試しください。");
+      const details = getErrorDetails(error);
+      if (details) {
+        setFieldErrors(details);
       }
+      setFormError(toErrorMessage(error, "登録に失敗しました。しばらくしてから再度お試しください。"));
     } finally {
       setSubmitting(false);
     }

--- a/frontend/components/study-record/SearchForm.tsx
+++ b/frontend/components/study-record/SearchForm.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { toErrorMessage } from "@/lib/api";
 import { listCategories } from "@/lib/category";
 import type { Category } from "@/types/category";
 import type { StudyRecordSearchParams } from "@/lib/study-record";
@@ -28,7 +28,7 @@ export default function SearchForm({ onSearch }: SearchFormProps) {
       .then(setCategories)
       .catch((e) => {
         setCategoriesError(
-          e instanceof ApiError ? e.message : "カテゴリ一覧の取得に失敗しました。",
+          toErrorMessage(e, "カテゴリ一覧の取得に失敗しました。"),
         );
       });
   }, []);

--- a/frontend/components/study-record/StudyRecordForm.tsx
+++ b/frontend/components/study-record/StudyRecordForm.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import StarRating from "@/components/study-record/StarRating";
 import ErrorMessage from "@/components/common/ErrorMessage";
-import { ApiError } from "@/lib/api";
+import { getErrorDetails, toErrorMessage } from "@/lib/api";
 import { listCategories } from "@/lib/category";
 import type { Category } from "@/types/category";
 import type { StudyRecordRequest } from "@/types/study-record";
@@ -83,9 +83,7 @@ export default function StudyRecordForm({
     listCategories()
       .then(setCategories)
       .catch((e) => {
-        setCategoriesError(
-          e instanceof ApiError ? e.message : "カテゴリ一覧の取得に失敗しました。",
-        );
+        setCategoriesError(toErrorMessage(e, "カテゴリ一覧の取得に失敗しました。"));
       });
   }, []);
 
@@ -123,14 +121,11 @@ export default function StudyRecordForm({
     try {
       await onSubmit(values);
     } catch (e) {
-      if (e instanceof ApiError) {
-        if (e.details) {
-          setFieldErrors(e.details);
-        }
-        setFormError(e.message);
-      } else {
-        setFormError("保存に失敗しました。しばらくしてから再度お試しください。");
+      const details = getErrorDetails(e);
+      if (details) {
+        setFieldErrors(details);
       }
+      setFormError(toErrorMessage(e, "保存に失敗しました。しばらくしてから再度お試しください。"));
     } finally {
       setSubmitting(false);
     }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -13,6 +13,14 @@ export class ApiError extends Error {
   }
 }
 
+export function toErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof ApiError ? error.message : fallback;
+}
+
+export function getErrorDetails(error: unknown): Record<string, string> | undefined {
+  return error instanceof ApiError ? error.details : undefined;
+}
+
 export function getCsrfTokenFromCookie(): string | undefined {
   if (typeof document === "undefined") {
     return undefined;


### PR DESCRIPTION
## 概要
Issue #35 の実装。`instanceof ApiError`を使ったエラー変換ロジックが15箇所に重複していたため、`lib/api.ts`に純粋関数を追加して置き換える。

## 変更内容

### 追加した関数（`lib/api.ts`）
```ts
export function toErrorMessage(error: unknown, fallback: string): string {
  return error instanceof ApiError ? error.message : fallback;
}

export function getErrorDetails(error: unknown): Record<string, string> | undefined {
  return error instanceof ApiError ? error.details : undefined;
}
```

### 置き換え対象
- **パターンA（単純、11箇所）**：`e instanceof ApiError ? e.message : "..."` → `toErrorMessage(e, "...")`
  - `study-records/page.tsx`(×2)、`study-records/[id]/edit/page.tsx`、`admin/users/page.tsx`、`admin/users/[id]/study-records/page.tsx`、`admin/categories/page.tsx`(×4)、`dashboard/page.tsx`、`SearchForm.tsx`、`StudyRecordForm.tsx`(カテゴリ取得部分)
- **パターンB（複雑、3箇所）**：`if (e instanceof ApiError) { if (e.details) ...; ... } else { ... }` → `getErrorDetails(e)` + `toErrorMessage(e, "...")`
  - `login/page.tsx`、`register/page.tsx`、`StudyRecordForm.tsx`(submit部分)

`register.tsx`・`StudyRecordForm.tsx`の「`details`が存在する場合のみ`setFieldErrors`を呼ぶ」という既存の条件分岐は、`getErrorDetails`が非`ApiError`時に`undefined`を返す性質を利用してそのまま維持している。

## 確定した設計方針（実装内容）
- React stateの更新（`setError`/`setFormError`/`setFieldErrors`等）の副作用は共通化せず、各呼び出し元にそのまま残した
- 共通化したのは「ApiErrorからメッセージ・detailsを取り出す」という小さな純粋関数のみ
- 表示文言・既存の挙動は変更していない

## 動作確認
- `npm run lint` → 通過
- `npx tsc --noEmit` → 通過
- `npm run test` → 17件全て通過（`SearchForm.test.tsx`のエラー表示テストも無修正で通過）
- `npm run build` → 通過
- Docker上でPlaywrightにより、ユーザー名重複エラー（register、`details`経路）、ログイン失敗エラー（login）、正常系のダッシュボード表示を実際に確認し、表示文言・挙動に変化がないことを確認

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)