### PR TITLE
Phase 9: ADMINユーザー情報取得改善（GET /api/admin/users/{id}追加）

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -23,6 +23,15 @@ def list_users(
     return admin_service.list_users(db)
 
 
+@router.get("/users/{user_id}", response_model=UserResponse)
+def get_user(
+    user_id: int,
+    current_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> UserResponse:
+    return admin_service.get_user_or_404(db, user_id)
+
+
 @router.get("/users/{user_id}/study-records", response_model=StudyRecordListResponse)
 def list_user_study_records(
     user_id: int,

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -92,6 +92,39 @@ def test_list_users_forbidden_for_non_admin(client, db_session):
     assert response.json()["error"]["code"] == "ADMIN_REQUIRED"
 
 
+# --- 単一ユーザー取得 ---
+
+
+def test_get_user_success(client, db_session):
+    register_and_login(client, username="alice")
+    alice = db_session.query(User).filter(User.username == "alice").first()
+
+    register_and_login_as_admin(client, db_session, username="adminuser")
+    response = client.get(f"/api/admin/users/{alice.id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == alice.id
+    assert body["username"] == "alice"
+    assert body["role"] == "USER"
+
+
+def test_get_user_nonexistent(client, db_session):
+    register_and_login_as_admin(client, db_session, username="adminuser")
+    response = client.get("/api/admin/users/999999")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "USER_NOT_FOUND"
+
+
+def test_get_user_forbidden_for_non_admin(client, db_session):
+    register_and_login(client, username="owner")
+    owner = db_session.query(User).filter(User.username == "owner").first()
+
+    register_and_login(client, username="bob")
+    response = client.get(f"/api/admin/users/{owner.id}")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ADMIN_REQUIRED"
+
+
 # --- 他ユーザーの学習記録閲覧 ---
 
 

--- a/frontend/app/(protected)/admin/users/[id]/study-records/page.tsx
+++ b/frontend/app/(protected)/admin/users/[id]/study-records/page.tsx
@@ -7,7 +7,7 @@ import SearchForm from "@/components/study-record/SearchForm";
 import Pagination from "@/components/common/Pagination";
 import ErrorMessage from "@/components/common/ErrorMessage";
 import { toErrorMessage } from "@/lib/api";
-import { getUserStudyRecords, listUsers } from "@/lib/admin";
+import { getUser, getUserStudyRecords } from "@/lib/admin";
 import type { StudyRecordSearchParams } from "@/lib/study-record";
 import { understandingLevelStars } from "@/lib/understanding-level";
 import type { StudyRecord } from "@/types/study-record";
@@ -29,10 +29,10 @@ export default function AdminUserStudyRecordsPage() {
   useEffect(() => {
     let cancelled = false;
 
-    listUsers()
-      .then((users) => {
+    getUser(userId)
+      .then((user) => {
         if (cancelled) return;
-        setTargetUser(users.find((u) => u.id === userId) ?? null);
+        setTargetUser(user);
       })
       .catch(() => {
         /* ユーザー名表示は補助情報のため、失敗しても一覧の取得は継続する */

--- a/frontend/lib/admin.ts
+++ b/frontend/lib/admin.ts
@@ -7,6 +7,10 @@ export function listUsers(): Promise<User[]> {
   return apiFetch<User[]>("/api/admin/users");
 }
 
+export function getUser(userId: number): Promise<User> {
+  return apiFetch<User>(`/api/admin/users/${userId}`);
+}
+
 export function getUserStudyRecords(
   userId: number,
   params: StudyRecordSearchParams = {},


### PR DESCRIPTION
## 概要
Issue #36 の実装。他ユーザー学習記録閲覧画面が対象ユーザー1人のusername表示のためだけに全ユーザー一覧APIを叩いていた非効率な実装を、単一ユーザー取得専用エンドポイントに置き換える。

## 変更内容

### Backend
- `GET /api/admin/users/{id}` を`app/api/admin.py`に追加
  - `require_admin`で認可
  - 既存の`admin_service.get_user_or_404`をそのまま利用（新規ロジックはルーター1つのみ）
  - レスポンスは既存の`UserResponse`スキーマを流用
- `tests/test_admin.py`に3件追加
  - 正常系（ADMINが対象ユーザー情報を取得できる）
  - 存在しないユーザーIDで404 `USER_NOT_FOUND`
  - USER権限でのアクセスで403 `ADMIN_REQUIRED`

### Frontend
- `lib/admin.ts`に`getUser(userId: number): Promise<User>`を追加
- `admin/users/[id]/study-records/page.tsx`の`listUsers().find(...)`を`getUser(userId)`に差し替え

## 動作確認
- `pytest tests/ -v` → 97件（既存94件+新規3件）全て通過
- `ruff check .` / `ruff format --check .` → 通過
- `npm run lint` / `npx tsc --noEmit` / `npm run test`（17件） / `npm run build` → 全て通過
- APIレベルで正常系・404・403をcurlで確認
- Docker上でPlaywrightにより、対象ページが`GET /api/admin/users`（全件）ではなく`GET /api/admin/users/{id}`（単一）を呼ぶようになったこと、ユーザー名表示が正しく機能することを確認

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)