### PR TITLE
Phase 9: CLAUDE.mdへのGitHub運用ルール追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,34 @@
 # StudyLog開発ルール
 
+## Git運用
+
+### 基本フロー
+
+すべての変更は以下の順序で進める。
+
+1. GitHub Issueを作成する（何を実現する作業なのかが一目で分かる短いタイトルにする）
+2. Issueに対応する作業ブランチを作成する
+3. 実装する
+4. テストを実行する
+   - Backend: `pytest tests/ -v`、`ruff check .`、`ruff format --check .`
+   - Frontend: `npm run lint`、`npx tsc --noEmit`、`npm run test`、`npm run build`
+5. コミットする
+6. Pull Requestを作成する（対応するIssueへの参照を含める。例：`Closes #12`）
+7. GitHub Actions（CI）の`backend`・`frontend`両ジョブが成功することを確認する
+8. ユーザーの確認・承認を得てからマージする
+
+### ブランチ命名
+
+`feature/{Issue番号}-{短い説明}`の形式に統一する（例：`feature/12-card-edit`）。短い説明は英語・ハイフン区切り。機能追加以外も`feature/`プレフィックスで統一する。1つのブランチで複数のIssueを同時に扱わない。
+
+### mainブランチへの直接push禁止
+
+`main`ブランチへの直接pushは禁止する。すべての変更はブランチを作成し、Pull Request経由で`main`に取り込む。`main`にはBranch Protection Ruleが設定されており、GitHub Actionsの`backend`・`frontend`ジョブが成功しない限りマージできない（管理者にも適用される設定）。
+
+### Pull Requestのマージ
+
+Pull Requestのマージは、CIの成功を確認した上で、必ずユーザーの確認・承認を得てから行う。Claude Codeが自身の判断でマージを実行しない。
+
 ## エラー・不具合調査の記録
 
 開発中に発生したエラー・不具合（バグ報告、原因不明のクラッシュ、テスト失敗の原因調査など）について、再現手順や原因調査を行った場合は、`docs/incidents/` 配下にMarkdownファイルとして記録する。


### PR DESCRIPTION
## 概要
Issue #42 の実装。Phase 1から一貫して守られてきたGit運用の型を、CLAUDE.mdに明文化する。

## 変更内容
`CLAUDE.md`に「Git運用」節を追加。

- **基本フロー**：Issue作成→ブランチ作成→実装→テスト（Backend/Frontendそれぞれのコマンド明記）→Commit→PR作成→CI成功確認→ユーザー確認後にMerge
- **ブランチ命名**：`feature/{Issue番号}-{短い説明}`
- **mainブランチへの直接push禁止**：Branch Protection Rule（backend/frontendジョブ必須、管理者にも適用）の実際の設定内容を記載
- **Pull Requestのマージ**：CI成功確認後、必ずユーザーの確認・承認を得てから行う旨を明記

既存の「エラー・不具合調査の記録」節はそのまま維持し、CLAUDE.mdを「プロジェクト全体で常に守るルール」の唯一の置き場として整理した。

## 確認
Branch Protectionの実際の設定（`gh api repos/.../branches/main/protection`）と記載内容が一致していることを確認済み（`required_status_checks.contexts: ["backend", "frontend"]`、`enforce_admins: true`）。

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)