### PR TITLE
ログイン画面に新規登録ページへの導線を追加

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import ErrorMessage from "@/components/common/ErrorMessage";
 import { toErrorMessage } from "@/lib/api";
 import { login } from "@/lib/auth";
@@ -58,6 +59,7 @@ export default function LoginPage() {
           ログイン
         </button>
       </form>
+      <Link href="/register">新規登録はこちら</Link>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- 登録ページ (`/register`) には「ログインはこちら」のリンクがある一方、ログインページ (`/login`) には対応するリンクがなく片方向の導線だった
- `frontend/app/login/page.tsx` に `Link` をimportし、フォーム直後に「新規登録はこちら」リンクを追加して対称的な導線にした

Closes #48

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（17 tests passed）
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)