### PR TITLE
Phase 10-1: Design System Foundation

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,17 +1,45 @@
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+  /* Color - Surface */
+  --color-bg: #0F1117;
+  --color-surface: #161B22;
+  --color-surface-hover: #1C2128;
+  --color-border: #30363D;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  /* Color - Text */
+  --color-text-primary: #F8FAFC;
+  --color-text-secondary: #94A3B8;
+  --color-text-muted: #6B7280;
+
+  /* Color - Accent */
+  --color-accent: #6366F1;
+  --color-accent-hover: #818CF8;
+
+  /* Color - Status */
+  --color-success: #22C55E;
+  --color-warning: #F59E0B;
+  --color-danger: #EF4444;
+  --color-danger-hover: #DC2626;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+
+  /* Shadow */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+
+  /* Spacing */
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 32px;
 }
 
 html {
   height: 100%;
+  color-scheme: dark;
 }
 
 html,
@@ -24,9 +52,9 @@ body {
   min-height: 100%;
   display: flex;
   flex-direction: column;
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  color: var(--color-text-primary);
+  background: var(--color-bg);
+  font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -42,8 +70,21 @@ a {
   text-decoration: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
+input,
+select,
+textarea {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm);
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
 }

--- a/frontend/components/common/Loading.module.css
+++ b/frontend/components/common/Loading.module.css
@@ -3,6 +3,6 @@
   align-items: center;
   justify-content: center;
   min-height: 200px;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 0.95rem;
 }

--- a/frontend/components/layout/Header.module.css
+++ b/frontend/components/layout/Header.module.css
@@ -4,8 +4,8 @@
   justify-content: space-between;
   padding: 0 16px;
   height: 56px;
-  border-bottom: 1px solid #e0e0e0;
-  background: #ffffff;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
 }
 
 .left {
@@ -21,11 +21,13 @@
   font-size: 1.4rem;
   cursor: pointer;
   padding: 4px 8px;
+  color: var(--color-text-primary);
 }
 
 .logo {
   font-weight: bold;
   font-size: 1.1rem;
+  color: var(--color-text-primary);
 }
 
 .userMenu {
@@ -38,6 +40,7 @@
   font-size: 0.95rem;
   cursor: pointer;
   padding: 4px 8px;
+  color: var(--color-text-primary);
 }
 
 .dropdown {
@@ -45,10 +48,10 @@
   right: 0;
   top: 100%;
   margin-top: 4px;
-  background: #ffffff;
-  border: 1px solid #e0e0e0;
-  border-radius: 4px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
   min-width: 120px;
   z-index: 20;
 }
@@ -62,10 +65,11 @@
   border: none;
   cursor: pointer;
   font-size: 0.9rem;
+  color: var(--color-text-primary);
 }
 
 .dropdown button:hover {
-  background: #f5f5f5;
+  background: var(--color-surface-hover);
 }
 
 @media (max-width: 768px) {

--- a/frontend/components/layout/Sidebar.module.css
+++ b/frontend/components/layout/Sidebar.module.css
@@ -5,8 +5,8 @@
 .sidebar {
   width: 200px;
   flex-shrink: 0;
-  border-right: 1px solid #e0e0e0;
-  background: #fafafa;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface);
   padding: 16px 0;
 }
 
@@ -18,17 +18,18 @@
 
 .nav a {
   padding: 10px 20px;
-  color: #333;
+  color: var(--color-text-secondary);
   font-size: 0.95rem;
 }
 
 .nav a:hover {
-  background: #eeeeee;
+  background: var(--color-surface-hover);
+  color: var(--color-text-primary);
 }
 
 .divider {
   border: none;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--color-border);
   margin: 12px 20px;
 }
 
@@ -39,11 +40,12 @@
   cursor: pointer;
   padding: 10px 20px;
   font-size: 0.95rem;
-  color: #333;
+  color: var(--color-text-secondary);
 }
 
 .logoutButton:hover {
-  background: #eeeeee;
+  background: var(--color-surface-hover);
+  color: var(--color-text-primary);
 }
 
 @media (max-width: 768px) {

--- a/frontend/components/ui/Button.module.css
+++ b/frontend/components/ui/Button.module.css
@@ -1,0 +1,44 @@
+.primary,
+.secondary,
+.danger {
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.primary:disabled,
+.secondary:disabled,
+.danger:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.primary {
+  background: var(--color-accent);
+  color: var(--color-text-primary);
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.secondary {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.secondary:hover:not(:disabled) {
+  background: var(--color-surface-hover);
+}
+
+.danger {
+  background: var(--color-danger);
+  color: var(--color-text-primary);
+}
+
+.danger:hover:not(:disabled) {
+  background: var(--color-danger-hover);
+}

--- a/frontend/components/ui/Button.test.tsx
+++ b/frontend/components/ui/Button.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Button from "./Button";
+
+describe("Button", () => {
+  it("デフォルトではprimaryのクラスが適用される", () => {
+    render(<Button>送信</Button>);
+    expect(screen.getByRole("button", { name: "送信" }).className).toMatch(/primary/);
+  });
+
+  it("variantを指定するとそのクラスが適用される", () => {
+    render(<Button variant="danger">削除</Button>);
+    expect(screen.getByRole("button", { name: "削除" }).className).toMatch(/danger/);
+  });
+
+  it("disabled指定時は無効化される", () => {
+    render(<Button disabled>保存</Button>);
+    expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+  });
+
+  it("クリックするとonClickが呼ばれる", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>実行</Button>);
+
+    await user.click(screen.getByRole("button", { name: "実行" }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/components/ui/Button.tsx
+++ b/frontend/components/ui/Button.tsx
@@ -1,0 +1,12 @@
+import styles from "./Button.module.css";
+
+type ButtonVariant = "primary" | "secondary" | "danger";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+export default function Button({ variant = "primary", className, ...rest }: ButtonProps) {
+  const variantClass = styles[variant];
+  return <button className={[variantClass, className].filter(Boolean).join(" ")} {...rest} />;
+}

--- a/frontend/components/ui/Card.module.css
+++ b/frontend/components/ui/Card.module.css
@@ -1,0 +1,7 @@
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-lg);
+}

--- a/frontend/components/ui/Card.test.tsx
+++ b/frontend/components/ui/Card.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Card from "./Card";
+
+describe("Card", () => {
+  it("childrenが表示される", () => {
+    render(
+      <Card>
+        <p>カードの中身</p>
+      </Card>,
+    );
+    expect(screen.getByText("カードの中身")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -1,0 +1,10 @@
+import styles from "./Card.module.css";
+
+interface CardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Card({ children, className }: CardProps) {
+  return <div className={[styles.card, className].filter(Boolean).join(" ")}>{children}</div>;
+}

--- a/frontend/components/ui/FormField.module.css
+++ b/frontend/components/ui/FormField.module.css
@@ -1,0 +1,11 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-md);
+}
+
+.label {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}

--- a/frontend/components/ui/FormField.test.tsx
+++ b/frontend/components/ui/FormField.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FormField from "./FormField";
+
+describe("FormField", () => {
+  it("labelとchildrenが表示される", () => {
+    render(
+      <FormField label="ユーザー名" htmlFor="username">
+        <input id="username" />
+      </FormField>,
+    );
+    expect(screen.getByLabelText("ユーザー名")).toBeInTheDocument();
+  });
+
+  it("errorがある場合はエラーメッセージが表示される", () => {
+    render(
+      <FormField label="ユーザー名" htmlFor="username" error="必須です">
+        <input id="username" />
+      </FormField>,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("必須です");
+  });
+
+  it("errorがない場合はエラーメッセージが表示されない", () => {
+    render(
+      <FormField label="ユーザー名" htmlFor="username">
+        <input id="username" />
+      </FormField>,
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/ui/FormField.tsx
+++ b/frontend/components/ui/FormField.tsx
@@ -1,0 +1,21 @@
+import ErrorMessage from "@/components/common/ErrorMessage";
+import styles from "./FormField.module.css";
+
+interface FormFieldProps {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  children: React.ReactNode;
+}
+
+export default function FormField({ label, htmlFor, error, children }: FormFieldProps) {
+  return (
+    <div className={styles.field}>
+      <label htmlFor={htmlFor} className={styles.label}>
+        {label}
+      </label>
+      {children}
+      {error && <ErrorMessage message={error} />}
+    </div>
+  );
+}

--- a/frontend/components/ui/PageHeader.module.css
+++ b/frontend/components/ui/PageHeader.module.css
@@ -1,0 +1,18 @@
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-lg);
+}
+
+.title {
+  font-size: 1.4rem;
+  color: var(--color-text-primary);
+}
+
+.description {
+  margin-top: var(--spacing-xs);
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}

--- a/frontend/components/ui/PageHeader.test.tsx
+++ b/frontend/components/ui/PageHeader.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PageHeader from "./PageHeader";
+
+describe("PageHeader", () => {
+  it("titleが表示される", () => {
+    render(<PageHeader title="ダッシュボード" />);
+    expect(screen.getByRole("heading", { name: "ダッシュボード" })).toBeInTheDocument();
+  });
+
+  it("descriptionを指定すると表示される", () => {
+    render(<PageHeader title="ダッシュボード" description="学習状況の概要" />);
+    expect(screen.getByText("学習状況の概要")).toBeInTheDocument();
+  });
+
+  it("descriptionを指定しない場合は表示されない", () => {
+    const { container } = render(<PageHeader title="ダッシュボード" />);
+    expect(container.querySelector("p")).not.toBeInTheDocument();
+  });
+
+  it("actionを指定すると表示される", () => {
+    render(<PageHeader title="ダッシュボード" action={<button>登録</button>} />);
+    expect(screen.getByRole("button", { name: "登録" })).toBeInTheDocument();
+  });
+
+  it("actionを指定しない場合は表示されない", () => {
+    render(<PageHeader title="ダッシュボード" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/ui/PageHeader.tsx
+++ b/frontend/components/ui/PageHeader.tsx
@@ -1,0 +1,19 @@
+import styles from "./PageHeader.module.css";
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}
+
+export default function PageHeader({ title, description, action }: PageHeaderProps) {
+  return (
+    <div className={styles.header}>
+      <div>
+        <h1 className={styles.title}>{title}</h1>
+        {description && <p className={styles.description}>{description}</p>}
+      </div>
+      {action && <div className={styles.action}>{action}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `frontend/app/globals.css` にModern Dark用のDesign Token（色・角丸・shadow・spacing）を追加し、標準テーマとして固定
- `prefers-color-scheme` 依存の分岐を廃止、旧 `--background` / `--foreground` を廃止
- input/select/textareaの基本スタイル（background/border/color/border-radius/padding/focus）をグローバルCSSに追加（レイアウト目的の指定は含めていない）
- `Header.module.css` / `Sidebar.module.css` / `Loading.module.css` のハードコード色をToken参照に置き換え（構造・ハンバーガーメニュー・モバイルスライド・オーバーレイ機構は変更なし）
- `frontend/components/ui/` を新設し、Button（primary/secondary/danger）・Card・FormField・PageHeaderを実装
- 各コンポーネントに軽量なユニットテストを追加

## Out of scope（後続Issueで対応）
- Login/Register、Dashboard、Study Records、Categories、Admin Usersの本格的なUI置き換え
- Dashboardのチャート色（`#4f46e5`）のToken化
- Table/Modalコンポーネントの新設
- Tailwind等の導入、テーマ切り替え機能

Closes #50

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（30 tests passed）
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)