### PR TITLE
Phase 10-2: Login / Register Redesign

### DIFF
--- a/frontend/app/login/page.module.css
+++ b/frontend/app/login/page.module.css
@@ -1,0 +1,58 @@
+.wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg);
+}
+
+.card {
+  width: 100%;
+  max-width: 360px;
+}
+
+.brand {
+  text-align: center;
+  margin-bottom: var(--spacing-xl);
+}
+
+.brandName {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: var(--color-text-primary);
+}
+
+.brandTagline {
+  margin-top: var(--spacing-xs);
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+}
+
+.input {
+  width: 100%;
+}
+
+.submit {
+  width: 100%;
+  margin-top: var(--spacing-sm);
+}
+
+.footer {
+  margin-top: var(--spacing-lg);
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.link {
+  color: var(--color-accent);
+}
+
+.link:hover {
+  color: var(--color-accent-hover);
+}

--- a/frontend/app/login/page.test.tsx
+++ b/frontend/app/login/page.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+import LoginPage from "./page";
+
+describe("LoginPage", () => {
+  it("ログイン画面の主要な要素が表示される", () => {
+    render(<LoginPage />);
+    expect(screen.getByRole("heading", { name: "ログイン" })).toBeInTheDocument();
+    expect(screen.getByLabelText("ユーザー名")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "ログイン" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "新規登録はこちら" })).toHaveAttribute(
+      "href",
+      "/register",
+    );
+  });
+});

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -4,8 +4,13 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import ErrorMessage from "@/components/common/ErrorMessage";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import FormField from "@/components/ui/FormField";
+import PageHeader from "@/components/ui/PageHeader";
 import { toErrorMessage } from "@/lib/api";
 import { login } from "@/lib/auth";
+import styles from "./page.module.css";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -30,36 +35,49 @@ export default function LoginPage() {
   }
 
   return (
-    <main>
-      <h1>ログイン</h1>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor="username">ユーザー名</label>
-          <input
-            id="username"
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-          />
+    <main className={styles.wrapper}>
+      <Card className={styles.card}>
+        <div className={styles.brand}>
+          <p className={styles.brandName}>StudyLog</p>
+          <p className={styles.brandTagline}>Learn. Track. Grow.</p>
         </div>
 
-        <div>
-          <label htmlFor="password">パスワード</label>
-          <input
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-        </div>
+        <PageHeader title="ログイン" />
 
-        {formError && <ErrorMessage message={formError} />}
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <FormField label="ユーザー名" htmlFor="username">
+            <input
+              id="username"
+              type="text"
+              className={styles.input}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+          </FormField>
 
-        <button type="submit" disabled={submitting}>
-          ログイン
-        </button>
-      </form>
-      <Link href="/register">新規登録はこちら</Link>
+          <FormField label="パスワード" htmlFor="password">
+            <input
+              id="password"
+              type="password"
+              className={styles.input}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </FormField>
+
+          {formError && <ErrorMessage message={formError} />}
+
+          <Button type="submit" disabled={submitting} className={styles.submit}>
+            ログイン
+          </Button>
+        </form>
+
+        <p className={styles.footer}>
+          <Link href="/register" className={styles.link}>
+            新規登録はこちら
+          </Link>
+        </p>
+      </Card>
     </main>
   );
 }

--- a/frontend/app/register/page.module.css
+++ b/frontend/app/register/page.module.css
@@ -1,0 +1,58 @@
+.wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg);
+}
+
+.card {
+  width: 100%;
+  max-width: 360px;
+}
+
+.brand {
+  text-align: center;
+  margin-bottom: var(--spacing-xl);
+}
+
+.brandName {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: var(--color-text-primary);
+}
+
+.brandTagline {
+  margin-top: var(--spacing-xs);
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+}
+
+.input {
+  width: 100%;
+}
+
+.submit {
+  width: 100%;
+  margin-top: var(--spacing-sm);
+}
+
+.footer {
+  margin-top: var(--spacing-lg);
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.link {
+  color: var(--color-accent);
+}
+
+.link:hover {
+  color: var(--color-accent-hover);
+}

--- a/frontend/app/register/page.test.tsx
+++ b/frontend/app/register/page.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+import RegisterPage from "./page";
+
+describe("RegisterPage", () => {
+  it("登録画面の主要な要素が表示される", () => {
+    render(<RegisterPage />);
+    expect(screen.getByRole("heading", { name: "ユーザー登録" })).toBeInTheDocument();
+    expect(screen.getByLabelText("ユーザー名")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+    expect(screen.getByLabelText("パスワード確認")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "登録する" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "ログインはこちら" })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+  });
+});

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -4,8 +4,13 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import ErrorMessage from "@/components/common/ErrorMessage";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import FormField from "@/components/ui/FormField";
+import PageHeader from "@/components/ui/PageHeader";
 import { getErrorDetails, toErrorMessage } from "@/lib/api";
 import { register } from "@/lib/auth";
+import styles from "./page.module.css";
 
 const USERNAME_PATTERN = /^[A-Za-z0-9_-]{1,25}$/;
 
@@ -86,51 +91,63 @@ export default function RegisterPage() {
   }
 
   return (
-    <main>
-      <h1>ユーザー登録</h1>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor="username">ユーザー名</label>
-          <input
-            id="username"
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-          />
-          {fieldErrors.username && <ErrorMessage message={fieldErrors.username} />}
+    <main className={styles.wrapper}>
+      <Card className={styles.card}>
+        <div className={styles.brand}>
+          <p className={styles.brandName}>StudyLog</p>
+          <p className={styles.brandTagline}>Learn. Track. Grow.</p>
         </div>
 
-        <div>
-          <label htmlFor="password">パスワード</label>
-          <input
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          {fieldErrors.password && <ErrorMessage message={fieldErrors.password} />}
-        </div>
+        <PageHeader title="ユーザー登録" />
 
-        <div>
-          <label htmlFor="password_confirmation">パスワード確認</label>
-          <input
-            id="password_confirmation"
-            type="password"
-            value={passwordConfirmation}
-            onChange={(e) => setPasswordConfirmation(e.target.value)}
-          />
-          {fieldErrors.password_confirmation && (
-            <ErrorMessage message={fieldErrors.password_confirmation} />
-          )}
-        </div>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <FormField label="ユーザー名" htmlFor="username" error={fieldErrors.username}>
+            <input
+              id="username"
+              type="text"
+              className={styles.input}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+          </FormField>
 
-        {formError && <ErrorMessage message={formError} />}
+          <FormField label="パスワード" htmlFor="password" error={fieldErrors.password}>
+            <input
+              id="password"
+              type="password"
+              className={styles.input}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </FormField>
 
-        <button type="submit" disabled={submitting}>
-          登録する
-        </button>
-      </form>
-      <Link href="/login">ログインはこちら</Link>
+          <FormField
+            label="パスワード確認"
+            htmlFor="password_confirmation"
+            error={fieldErrors.password_confirmation}
+          >
+            <input
+              id="password_confirmation"
+              type="password"
+              className={styles.input}
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+            />
+          </FormField>
+
+          {formError && <ErrorMessage message={formError} />}
+
+          <Button type="submit" disabled={submitting} className={styles.submit}>
+            登録する
+          </Button>
+        </form>
+
+        <p className={styles.footer}>
+          <Link href="/login" className={styles.link}>
+            ログインはこちら
+          </Link>
+        </p>
+      </Card>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Login / RegisterをPhase 10-1のDesign System（Card / PageHeader / FormField / Button）で再構築
- 画面中央配置のSaaS風カードレイアウトに変更
- カード上部に「StudyLog / Learn. Track. Grow.」のブランド表現を追加（画像・外部ライブラリなし、CSSのみ）
- 「ログインはこちら」「新規登録はこちら」リンクを`--color-accent` / hover時`--color-accent-hover`で装飾
- 新規CSS: `frontend/app/login/page.module.css`, `frontend/app/register/page.module.css`（globals.cssのDesign Tokenのみ使用、色のハードコードなし）

## 変更していないもの
- `frontend/lib/auth.ts`（認証API呼び出し）
- バリデーション関数（`validateUsername`, `validatePassword`等）
- 認証フロー（`router.push` / `router.replace`）
- 状態管理（useState, value, onChange）
- アクセシビリティ構造（label, htmlFor, input id, ErrorMessageのrole="alert"）

Closes #52

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（32 tests passed、Login/Registerの表示確認テストを追加）
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)