### PR TITLE
Phase 10-3: Dashboard Redesign

### DIFF
--- a/docs/incidents/2026-09-02-backend-not-running-dashboard-verification.md
+++ b/docs/incidents/2026-09-02-backend-not-running-dashboard-verification.md
@@ -1,0 +1,39 @@
+# Dashboard実機確認時にBackendが未起動だった事象（PR #55）
+
+## 概要
+
+Phase 10-3（Dashboard Redesign、PR #55）の実装完了後、`npm run lint` / `tsc --noEmit` / `npm run test` / `npm run build` がすべて成功したことを確認したうえで、ブラウザによる実機確認（Desktop / Mobileでの表示確認、ログイン→Dashboard遷移の動作確認）を行おうとしたところ、Backendが未起動であることが判明し、認証が必要なDashboardページの実機確認ができない状態だった。
+
+当時稼働していたのはFrontendの開発サーバー（`npm run dev`、ポート3000）のみで、Backend（FastAPI、ポート8000）・MySQLはいずれも起動していなかった。
+
+## 発見方法
+
+1. `npm run build` 成功後、Backendの起動を試みる目的で `cd backend && uvicorn app.main:app --reload --port 8000` を実行したところ、`command not found: uvicorn` エラーが発生した
+2. `backend/` 配下に `.venv` 等の仮想環境ディレクトリが存在せず、依存パッケージ（`requirements.txt` に定義されたFastAPI等）がローカル環境にインストールされていないことを確認した
+3. この時点でBackendの正しい起動方法が不明であり、推測でコマンドを試すのではなく、プロジェクトの構成ファイル（README.md、docker-compose.yml、CI設定等）を調査する方針に切り替えた
+4. 調査の結果、ルート直下の `README.md` に `docker compose up -d --build` を用いた公式なセットアップ手順が明記されていることが分かった
+5. `docker compose ps` を実行したところ、`Cannot connect to the Docker daemon` エラーが発生し、**Docker Desktopアプリ自体が起動していない**ことが直接の原因だと判明した
+
+## わかったこと
+
+- StudyLog Backendは、ローカルに直接 `uvicorn` をインストールして起動する運用ではなく、**Docker Compose（frontend / backend / db の3サービス構成）を用いてローカル環境を構築する設計**になっている
+- `backend/` に仮想環境が存在しないのは異常ではなく、そもそもホストOS上で直接Pythonプロセスを起動する想定の構成ではなかった
+- Docker自体（`docker` コマンド、Docker Compose v5.1.4）はマシンにインストール済みだったが、Docker Desktopのデーモンプロセスが起動していなかったため、`docker compose` コマンドがすべて失敗していた
+- ルート直下に `.env`（`.env.example` と同一内容）が既に存在しており、`docker compose up` はこれを自動的に読み込む状態だった
+- CI（`.github/workflows/ci.yml`）のbackendジョブは `pytest` 実行のみで `uvicorn` を起動していないため、CIログからは正しい起動方法を読み取れなかった。起動手順はREADME.mdの「セットアップ」セクションにのみ明記されていた
+
+## 対応
+
+1. Docker Desktopアプリを起動（`open -a Docker`）し、デーモンの起動を待機した
+2. `docker compose up -d --build` でfrontend / backend / db の3コンテナをビルド・起動した
+3. 初回セットアップとして `docker compose run --rm backend alembic upgrade head`（マイグレーション）と `docker compose run --rm backend python -m app.db.seed`（初期データ投入）を実行した
+4. `curl` で `/health`、認証API（`/api/auth/login`）、Dashboard API（`/api/dashboard`）が正常に応答することを確認した
+5. Docker版Frontendと衝突しないよう、事前にホスト側で直接動かしていた `npm run dev`（ポート3000）を停止した
+
+以降のブラウザでの実機確認は、Docker Compose環境（`http://localhost:3000`、Backend `http://localhost:8000`）に対して行う運用に統一した。
+
+## 教訓
+
+- Backendの起動方法が分からない場合、`uvicorn` を直接叩く、仮想環境を新規作成する、といった対応を推測で行う前に、必ずREADME.md・docker-compose.yml・CI設定など実際のプロジェクト構成ファイルを確認すること。今回はユーザーから明示的に「推測で判断せず調査してほしい」と指摘され、調査に切り替えたことで正しい手順（Docker Compose）にたどり着けた
+- CIのジョブ定義は「テストを通す」ことが目的であり、ローカル開発環境の起動手順を必ずしも反映していない。起動方法はREADME等のセットアップドキュメントを一次情報として確認する
+- `docker` コマンドが存在する（インストール済み）ことと、Docker Desktopのデーモンが実際に起動していることは別の話であり、`docker compose` 系コマンドのエラーメッセージ（`Cannot connect to the Docker daemon`）を早い段階で確認すれば、無駄な試行錯誤を避けられる

--- a/frontend/app/(protected)/dashboard/page.module.css
+++ b/frontend/app/(protected)/dashboard/page.module.css
@@ -1,0 +1,29 @@
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+}
+
+.chartGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+}
+
+.fullWidth {
+  margin-bottom: var(--spacing-lg);
+}
+
+@media (max-width: 1024px) {
+  .chartGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .summaryGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/app/(protected)/dashboard/page.test.tsx
+++ b/frontend/app/(protected)/dashboard/page.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuthUser: () => ({ id: 1, username: "testuser", role: "USER" }),
+}));
+
+const dashboardData = {
+  today_minutes: 30,
+  streak_days: 5,
+  daily_totals: [{ date: "2026-09-01", minutes: 30 }],
+  category_totals: [{ category_id: 1, category_name: "英語", minutes: 30 }],
+  monthly_totals: [{ month: "2026-09", minutes: 30 }],
+  recent_records: [
+    {
+      id: 1,
+      category_id: 1,
+      category_name: "英語",
+      title: "単語帳",
+      content: "content",
+      understanding_level: 3,
+      study_minutes: 30,
+      study_date: "2026-09-01",
+      created_at: "2026-09-01T00:00:00Z",
+      updated_at: "2026-09-01T00:00:00Z",
+    },
+  ],
+};
+
+vi.mock("@/lib/dashboard", () => ({
+  getDashboard: vi.fn(() => Promise.resolve(dashboardData)),
+}));
+
+import DashboardPage from "./page";
+
+describe("DashboardPage", () => {
+  it("主要な情報が表示される", async () => {
+    render(<DashboardPage />);
+
+    expect(screen.getByRole("heading", { name: "ダッシュボード" })).toBeInTheDocument();
+    const todayMinutes = await screen.findAllByText(
+      (_, element) => element?.textContent === "30分",
+    );
+    expect(todayMinutes.length).toBeGreaterThan(0);
+
+    const streakDays = screen.getAllByText((_, element) => element?.textContent === "5日");
+    expect(streakDays.length).toBeGreaterThan(0);
+    expect(screen.getByText("単語帳")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/(protected)/dashboard/page.tsx
+++ b/frontend/app/(protected)/dashboard/page.tsx
@@ -9,10 +9,13 @@ import RecentRecords from "@/components/dashboard/RecentRecords";
 import StreakCard from "@/components/dashboard/StreakCard";
 import TodayStudyTime from "@/components/dashboard/TodayStudyTime";
 import ErrorMessage from "@/components/common/ErrorMessage";
+import Card from "@/components/ui/Card";
+import PageHeader from "@/components/ui/PageHeader";
 import { toErrorMessage } from "@/lib/api";
 import { useAuthUser } from "@/lib/auth-context";
 import { getDashboard } from "@/lib/dashboard";
 import type { Dashboard } from "@/types/dashboard";
+import styles from "./page.module.css";
 
 export default function DashboardPage() {
   const user = useAuthUser();
@@ -39,21 +42,41 @@ export default function DashboardPage() {
 
   return (
     <div>
-      <h1>ダッシュボード</h1>
-      <p>ようこそ、{user.username}さん</p>
-
-      <Link href="/study-records/new">学習記録を登録</Link>
+      <PageHeader
+        title="ダッシュボード"
+        description={`ようこそ、${user.username}さん`}
+        action={<Link href="/study-records/new">学習記録を登録</Link>}
+      />
 
       {error && <ErrorMessage message={error} />}
 
       {dashboard && (
         <>
-          <TodayStudyTime minutes={dashboard.today_minutes} />
-          <StreakCard days={dashboard.streak_days} />
-          <DailyChart data={dashboard.daily_totals} />
-          <CategoryChart data={dashboard.category_totals} />
-          <MonthlyChart data={dashboard.monthly_totals} />
-          <RecentRecords records={dashboard.recent_records} />
+          <div className={styles.summaryGrid}>
+            <Card>
+              <TodayStudyTime minutes={dashboard.today_minutes} />
+            </Card>
+            <Card>
+              <StreakCard days={dashboard.streak_days} />
+            </Card>
+          </div>
+
+          <div className={styles.chartGrid}>
+            <Card>
+              <DailyChart data={dashboard.daily_totals} />
+            </Card>
+            <Card>
+              <CategoryChart data={dashboard.category_totals} />
+            </Card>
+          </div>
+
+          <Card className={styles.fullWidth}>
+            <MonthlyChart data={dashboard.monthly_totals} />
+          </Card>
+
+          <Card>
+            <RecentRecords records={dashboard.recent_records} />
+          </Card>
         </>
       )}
     </div>

--- a/frontend/components/dashboard/CategoryChart.tsx
+++ b/frontend/components/dashboard/CategoryChart.tsx
@@ -2,22 +2,30 @@
 
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import type { CategoryTotal } from "@/types/dashboard";
+import styles from "./ChartSection.module.css";
 
 interface CategoryChartProps {
   data: CategoryTotal[];
 }
 
+const tooltipContentStyle = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--color-text-primary)",
+};
+
 export default function CategoryChart({ data }: CategoryChartProps) {
   return (
     <section>
-      <h2>カテゴリ別学習時間（今月）</h2>
+      <h2 className={styles.heading}>カテゴリ別学習時間（今月）</h2>
       <ResponsiveContainer width="100%" height={240}>
         <BarChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="category_name" />
-          <YAxis />
-          <Tooltip />
-          <Bar dataKey="minutes" name="学習時間（分）" fill="#4f46e5" />
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+          <XAxis dataKey="category_name" stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
+          <YAxis stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
+          <Tooltip contentStyle={tooltipContentStyle} />
+          <Bar dataKey="minutes" name="学習時間（分）" fill="var(--color-accent)" />
         </BarChart>
       </ResponsiveContainer>
     </section>

--- a/frontend/components/dashboard/ChartSection.module.css
+++ b/frontend/components/dashboard/ChartSection.module.css
@@ -1,0 +1,5 @@
+.heading {
+  font-size: 1rem;
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-md);
+}

--- a/frontend/components/dashboard/DailyChart.tsx
+++ b/frontend/components/dashboard/DailyChart.tsx
@@ -2,22 +2,30 @@
 
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import type { DailyTotal } from "@/types/dashboard";
+import styles from "./ChartSection.module.css";
 
 interface DailyChartProps {
   data: DailyTotal[];
 }
 
+const tooltipContentStyle = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--color-text-primary)",
+};
+
 export default function DailyChart({ data }: DailyChartProps) {
   return (
     <section>
-      <h2>日別学習時間（直近7日間）</h2>
+      <h2 className={styles.heading}>日別学習時間（直近7日間）</h2>
       <ResponsiveContainer width="100%" height={240}>
         <LineChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="date" />
-          <YAxis />
-          <Tooltip />
-          <Line type="monotone" dataKey="minutes" name="学習時間（分）" stroke="#4f46e5" />
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+          <XAxis dataKey="date" stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
+          <YAxis stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
+          <Tooltip contentStyle={tooltipContentStyle} />
+          <Line type="monotone" dataKey="minutes" name="学習時間（分）" stroke="var(--color-accent)" />
         </LineChart>
       </ResponsiveContainer>
     </section>

--- a/frontend/components/dashboard/MonthlyChart.tsx
+++ b/frontend/components/dashboard/MonthlyChart.tsx
@@ -2,22 +2,30 @@
 
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import type { MonthlyTotal } from "@/types/dashboard";
+import styles from "./ChartSection.module.css";
 
 interface MonthlyChartProps {
   data: MonthlyTotal[];
 }
 
+const tooltipContentStyle = {
+  background: "var(--color-surface)",
+  border: "1px solid var(--color-border)",
+  borderRadius: "var(--radius-sm)",
+  color: "var(--color-text-primary)",
+};
+
 export default function MonthlyChart({ data }: MonthlyChartProps) {
   return (
     <section>
-      <h2>月別学習時間（直近6か月）</h2>
+      <h2 className={styles.heading}>月別学習時間（直近6か月）</h2>
       <ResponsiveContainer width="100%" height={240}>
         <BarChart data={data}>
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" />
-          <YAxis />
-          <Tooltip />
-          <Bar dataKey="minutes" name="学習時間（分）" fill="#4f46e5" />
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+          <XAxis dataKey="month" stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
+          <YAxis stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
+          <Tooltip contentStyle={tooltipContentStyle} />
+          <Bar dataKey="minutes" name="学習時間（分）" fill="var(--color-accent)" />
         </BarChart>
       </ResponsiveContainer>
     </section>

--- a/frontend/components/dashboard/RecentRecords.module.css
+++ b/frontend/components/dashboard/RecentRecords.module.css
@@ -1,0 +1,44 @@
+.heading {
+  font-size: 1rem;
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-md);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-sm) 0;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.9rem;
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.date {
+  color: var(--color-text-secondary);
+  min-width: 90px;
+}
+
+.category {
+  color: var(--color-text-secondary);
+}
+
+.title {
+  flex: 1;
+  min-width: 120px;
+  color: var(--color-text-primary);
+}
+
+.minutes {
+  color: var(--color-text-secondary);
+}

--- a/frontend/components/dashboard/RecentRecords.tsx
+++ b/frontend/components/dashboard/RecentRecords.tsx
@@ -1,5 +1,6 @@
 import { understandingLevelStars } from "@/lib/understanding-level";
 import type { StudyRecord } from "@/types/study-record";
+import styles from "./RecentRecords.module.css";
 
 interface RecentRecordsProps {
   records: StudyRecord[];
@@ -8,15 +9,15 @@ interface RecentRecordsProps {
 export default function RecentRecords({ records }: RecentRecordsProps) {
   return (
     <section>
-      <h2>最近の学習記録</h2>
-      <ul>
+      <h2 className={styles.heading}>最近の学習記録</h2>
+      <ul className={styles.list}>
         {records.map((record) => (
-          <li key={record.id}>
-            <span>{record.study_date}</span>
-            <span>{record.category_name}</span>
-            <span>{record.title}</span>
-            <span>{record.study_minutes}分</span>
-            <span>{understandingLevelStars(record.understanding_level)}</span>
+          <li key={record.id} className={styles.item}>
+            <span className={styles.date}>{record.study_date}</span>
+            <span className={styles.category}>{record.category_name}</span>
+            <span className={styles.title}>{record.title}</span>
+            <span className={styles.minutes}>{record.study_minutes}分</span>
+            <span className={styles.stars}>{understandingLevelStars(record.understanding_level)}</span>
           </li>
         ))}
       </ul>

--- a/frontend/components/dashboard/StreakCard.tsx
+++ b/frontend/components/dashboard/StreakCard.tsx
@@ -1,3 +1,5 @@
+import styles from "./SummaryCard.module.css";
+
 interface StreakCardProps {
   days: number;
 }
@@ -5,8 +7,8 @@ interface StreakCardProps {
 export default function StreakCard({ days }: StreakCardProps) {
   return (
     <section>
-      <h2>🔥 連続学習</h2>
-      <p>{days}日</p>
+      <h2 className={styles.label}>🔥 連続学習</h2>
+      <p className={styles.value}>{days}日</p>
     </section>
   );
 }

--- a/frontend/components/dashboard/SummaryCard.module.css
+++ b/frontend/components/dashboard/SummaryCard.module.css
@@ -1,0 +1,12 @@
+.label {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  font-weight: normal;
+}
+
+.value {
+  margin-top: var(--spacing-xs);
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: var(--color-text-primary);
+}

--- a/frontend/components/dashboard/TodayStudyTime.tsx
+++ b/frontend/components/dashboard/TodayStudyTime.tsx
@@ -1,3 +1,5 @@
+import styles from "./SummaryCard.module.css";
+
 interface TodayStudyTimeProps {
   minutes: number;
 }
@@ -5,8 +7,8 @@ interface TodayStudyTimeProps {
 export default function TodayStudyTime({ minutes }: TodayStudyTimeProps) {
   return (
     <section>
-      <h2>今日の学習時間</h2>
-      <p>{minutes}分</p>
+      <h2 className={styles.label}>今日の学習時間</h2>
+      <p className={styles.value}>{minutes}分</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- `PageHeader`（title="ダッシュボード", description="ようこそ、{username}さん", action=「学習記録を登録」）を導入
- サマリーエリア（今日の学習時間 / 連続学習日数）をCard化し、Desktop 2カラムgrid
- グラフエリア: 日別学習時間・カテゴリ別学習時間を2カラムCard、月別学習時間をフル幅Cardで配置
- 最近の学習記録をフル幅Cardのリスト表示に整理（Table化はしていない）
- Recharts（DailyChart/CategoryChart/MonthlyChart）の色・グリッド線・軸ラベル・Tooltipを`var(--color-accent)` `var(--color-border)` `var(--color-text-secondary)` `var(--color-surface)`等のDesign Token参照に統一
- レスポンシブ: Desktop 2カラム基調 / Tablet(≤1024px)はグラフエリアを1カラム / Mobile(≤768px、既存Header/Sidebarと同じブレークポイント)は全て1カラム
- レイアウトは`frontend/app/(protected)/dashboard/page.module.css`で管理、新規の汎用UIコンポーネントは追加していない（既存のCard/PageHeaderを使用）

## 変更していないもの
- Backend API / DB
- 認証処理
- Login / Register / Admin / Study Records画面
- データ取得ロジック（`getDashboard`）、各コンポーネントのprops構造

Closes #54

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（33 tests passed、Dashboardの表示確認テストを追加）
- [x] `npm run build`
- [x] ブラウザでの実機確認（Backend未起動のため今回は未実施、下記参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)