### PR TITLE
モバイル表示で編集・削除ボタンの文字位置がずれる問題を修正

### DIFF
--- a/frontend/app/(protected)/study-records/page.module.css
+++ b/frontend/app/(protected)/study-records/page.module.css
@@ -40,9 +40,13 @@
 .actions {
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
   gap: var(--spacing-sm);
 }
 
 .editButton {
   display: inline-block;
+  text-align: center;
+  white-space: nowrap;
+  flex-shrink: 0;
 }

--- a/frontend/components/ui/Button.module.css
+++ b/frontend/components/ui/Button.module.css
@@ -6,6 +6,8 @@
   padding: var(--spacing-sm) var(--spacing-md);
   font-size: 0.95rem;
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .primary:disabled,


### PR DESCRIPTION
## Summary
PR #59（Phase 10-4b）マージ直後のブラウザ確認で見つかった、Study Records一覧のモバイル表示における見た目の問題を修正する。この修正はPR #59のブランチ上で実施しユーザーの確認も得ていたが、確認完了前にPR #59がマージされたため、最後の修正コミット（`5b6857a`）がmainに未反映だった。本PRはそのコミットをcherry-pickして取り込むもの。

- 編集リンク（`<a>`）はUAデフォルトで`text-align: center`が効かず削除ボタンと文字位置がずれていたため、`.editButton`に`text-align: center`を追加
- `flex-wrap: nowrap`追加に伴いButtonコンポーネント側の文字が縦に折り返される問題が発生したため、`Button.module.css`の`.primary`/`.secondary`/`.danger`共通に`white-space: nowrap`・`flex-shrink: 0`を追加
- テーブルの`min-width`は640pxのまま変更なし

Closes #60

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（37 tests passed）
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)