### PR TITLE
Phase 10-5: Admin UI Polish（ユーザー一覧・ユーザー別学習記録）

### DIFF
--- a/frontend/app/(protected)/admin/users/[id]/study-records/page.module.css
+++ b/frontend/app/(protected)/admin/users/[id]/study-records/page.module.css
@@ -1,0 +1,40 @@
+.backButton {
+  display: inline-block;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.searchCard {
+  margin-bottom: var(--spacing-lg);
+}
+
+.tableCard {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 560px;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.9rem;
+}
+
+.table th {
+  color: var(--color-text-secondary);
+  font-weight: normal;
+}
+
+.table td {
+  color: var(--color-text-primary);
+}
+
+.table tbody tr:hover {
+  background: var(--color-surface-hover);
+}

--- a/frontend/app/(protected)/admin/users/[id]/study-records/page.test.tsx
+++ b/frontend/app/(protected)/admin/users/[id]/study-records/page.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "1" }),
+}));
+
+const record = {
+  id: 1,
+  category_id: 1,
+  category_name: "英語",
+  title: "単語帳",
+  content: "content",
+  understanding_level: 3,
+  study_minutes: 30,
+  study_date: "2026-09-01",
+  created_at: "2026-09-01T00:00:00Z",
+  updated_at: "2026-09-01T00:00:00Z",
+};
+
+vi.mock("@/lib/admin", () => ({
+  getUser: vi.fn(() => Promise.resolve({ id: 1, username: "testuser", role: "USER" })),
+  getUserStudyRecords: vi.fn(() =>
+    Promise.resolve({ items: [record], page: 1, page_size: 10, total: 1, total_pages: 1 }),
+  ),
+}));
+
+vi.mock("@/lib/category", () => ({
+  listCategories: vi.fn(() => Promise.resolve([])),
+}));
+
+import AdminUserStudyRecordsPage from "./page";
+
+describe("AdminUserStudyRecordsPage", () => {
+  it("主要な情報が表示される", async () => {
+    render(<AdminUserStudyRecordsPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "testuser さんの学習記録" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "ユーザー一覧に戻る" })).toHaveAttribute(
+      "href",
+      "/admin/users",
+    );
+    expect(await screen.findByText("単語帳")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/(protected)/admin/users/[id]/study-records/page.tsx
+++ b/frontend/app/(protected)/admin/users/[id]/study-records/page.tsx
@@ -6,12 +6,16 @@ import Link from "next/link";
 import SearchForm from "@/components/study-record/SearchForm";
 import Pagination from "@/components/common/Pagination";
 import ErrorMessage from "@/components/common/ErrorMessage";
+import buttonStyles from "@/components/ui/Button.module.css";
+import Card from "@/components/ui/Card";
+import PageHeader from "@/components/ui/PageHeader";
 import { toErrorMessage } from "@/lib/api";
 import { getUser, getUserStudyRecords } from "@/lib/admin";
 import type { StudyRecordSearchParams } from "@/lib/study-record";
 import { understandingLevelStars } from "@/lib/understanding-level";
 import type { StudyRecord } from "@/types/study-record";
 import type { User } from "@/types/auth";
+import styles from "./page.module.css";
 
 export default function AdminUserStudyRecordsPage() {
   const params = useParams<{ id: string }>();
@@ -70,36 +74,48 @@ export default function AdminUserStudyRecordsPage() {
 
   return (
     <div>
-      <h1>{targetUser ? `${targetUser.username} さんの学習記録` : "学習記録"}</h1>
+      <PageHeader
+        title={targetUser ? `${targetUser.username} さんの学習記録` : "学習記録"}
+        action={
+          <Link
+            href="/admin/users"
+            className={`${buttonStyles.secondary} ${styles.backButton}`}
+          >
+            ユーザー一覧に戻る
+          </Link>
+        }
+      />
 
-      <Link href="/admin/users">ユーザー一覧に戻る</Link>
-
-      <SearchForm onSearch={handleSearch} />
+      <Card className={styles.searchCard}>
+        <SearchForm onSearch={handleSearch} />
+      </Card>
 
       {error && <ErrorMessage message={error} />}
 
-      <table>
-        <thead>
-          <tr>
-            <th>学習日</th>
-            <th>カテゴリ</th>
-            <th>タイトル</th>
-            <th>学習時間</th>
-            <th>理解度</th>
-          </tr>
-        </thead>
-        <tbody>
-          {records.map((record) => (
-            <tr key={record.id}>
-              <td>{record.study_date}</td>
-              <td>{record.category_name}</td>
-              <td>{record.title}</td>
-              <td>{record.study_minutes}分</td>
-              <td>{understandingLevelStars(record.understanding_level)}</td>
+      <Card className={styles.tableCard}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>学習日</th>
+              <th>カテゴリ</th>
+              <th>タイトル</th>
+              <th>学習時間</th>
+              <th>理解度</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {records.map((record) => (
+              <tr key={record.id}>
+                <td>{record.study_date}</td>
+                <td>{record.category_name}</td>
+                <td>{record.title}</td>
+                <td>{record.study_minutes}分</td>
+                <td>{understandingLevelStars(record.understanding_level)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
 
       <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
     </div>

--- a/frontend/app/(protected)/admin/users/page.module.css
+++ b/frontend/app/(protected)/admin/users/page.module.css
@@ -1,0 +1,35 @@
+.tableCard {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.9rem;
+}
+
+.table th {
+  color: var(--color-text-secondary);
+  font-weight: normal;
+}
+
+.table td {
+  color: var(--color-text-primary);
+}
+
+.table tbody tr:hover {
+  background: var(--color-surface-hover);
+}
+
+.viewButton {
+  display: inline-block;
+  text-align: center;
+  white-space: nowrap;
+}

--- a/frontend/app/(protected)/admin/users/page.test.tsx
+++ b/frontend/app/(protected)/admin/users/page.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/admin", () => ({
+  listUsers: vi.fn(() =>
+    Promise.resolve([{ id: 1, username: "testuser", role: "USER" }]),
+  ),
+}));
+
+import AdminUsersPage from "./page";
+
+describe("AdminUsersPage", () => {
+  it("主要な情報が表示される", async () => {
+    render(<AdminUsersPage />);
+
+    expect(screen.getByRole("heading", { name: "ユーザー一覧" })).toBeInTheDocument();
+    expect(await screen.findByText("testuser")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "学習記録を見る" }),
+    ).toHaveAttribute("href", "/admin/users/1/study-records");
+  });
+});

--- a/frontend/app/(protected)/admin/users/page.tsx
+++ b/frontend/app/(protected)/admin/users/page.tsx
@@ -3,9 +3,13 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import ErrorMessage from "@/components/common/ErrorMessage";
+import buttonStyles from "@/components/ui/Button.module.css";
+import Card from "@/components/ui/Card";
+import PageHeader from "@/components/ui/PageHeader";
 import { toErrorMessage } from "@/lib/api";
 import { listUsers } from "@/lib/admin";
 import type { User } from "@/types/auth";
+import styles from "./page.module.css";
 
 export default function AdminUsersPage() {
   const [users, setUsers] = useState<User[]>([]);
@@ -31,30 +35,37 @@ export default function AdminUsersPage() {
 
   return (
     <div>
-      <h1>ユーザー一覧</h1>
+      <PageHeader title="ユーザー一覧" />
 
       {error && <ErrorMessage message={error} />}
 
-      <table>
-        <thead>
-          <tr>
-            <th>ユーザー名</th>
-            <th>権限</th>
-            <th>操作</th>
-          </tr>
-        </thead>
-        <tbody>
-          {users.map((user) => (
-            <tr key={user.id}>
-              <td>{user.username}</td>
-              <td>{user.role}</td>
-              <td>
-                <Link href={`/admin/users/${user.id}/study-records`}>学習記録を見る</Link>
-              </td>
+      <Card className={styles.tableCard}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>ユーザー名</th>
+              <th>権限</th>
+              <th>操作</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {users.map((user) => (
+              <tr key={user.id}>
+                <td>{user.username}</td>
+                <td>{user.role}</td>
+                <td>
+                  <Link
+                    href={`/admin/users/${user.id}/study-records`}
+                    className={`${buttonStyles.secondary} ${styles.viewButton}`}
+                  >
+                    学習記録を見る
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `admin/users/page.tsx`（title="ユーザー一覧"）・`admin/users/[id]/study-records/page.tsx`（title="{username} さんの学習記録"）にPageHeaderを導入
- ユーザー別学習記録ページのSearchFormをCardで囲む
- テーブル（ユーザー一覧・ユーザー別学習記録）は構造・データ処理を変更せず、Card内配置＋CSS Moduleでヘッダー行・罫線・セルpadding・行hoverを統一。モバイルは横スクロール対応
- 「学習記録を見る」「ユーザー一覧に戻る」リンクをButton secondaryの見た目に統一（Study Records一覧の「編集」と同じ手法：`Button.module.css`のクラスをLinkに直接適用）

## 対象外
- Categories管理（Phase 10-4aで対応済み）
- `admin/layout.tsx`（UI要素なし）
- Table共通コンポーネントの新設（既存方針を踏襲し見送り）
- Backend API / DB / 認証処理
- Login / Register / Dashboard / Study Records画面

Closes #62

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（39 tests passed。ユーザー一覧・ユーザー別学習記録の表示確認テストを追加）
- [x] `npm run build`
- [x] Docker Compose環境で`/health`・`/admin/users`の疎通確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)