### PR TITLE
Dashboard: 棒グラフの棒の幅を調整

### DIFF
--- a/frontend/components/dashboard/CategoryChart.tsx
+++ b/frontend/components/dashboard/CategoryChart.tsx
@@ -25,7 +25,7 @@ export default function CategoryChart({ data }: CategoryChartProps) {
           <XAxis dataKey="category_name" stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
           <YAxis stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
           <Tooltip contentStyle={tooltipContentStyle} />
-          <Bar dataKey="minutes" name="学習時間（分）" fill="var(--color-accent)" />
+          <Bar dataKey="minutes" name="学習時間（分）" fill="var(--color-accent)" maxBarSize={55} />
         </BarChart>
       </ResponsiveContainer>
     </section>

--- a/frontend/components/dashboard/MonthlyChart.tsx
+++ b/frontend/components/dashboard/MonthlyChart.tsx
@@ -25,7 +25,7 @@ export default function MonthlyChart({ data }: MonthlyChartProps) {
           <XAxis dataKey="month" stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
           <YAxis stroke="var(--color-text-secondary)" tick={{ fill: "var(--color-text-secondary)" }} />
           <Tooltip contentStyle={tooltipContentStyle} />
-          <Bar dataKey="minutes" name="学習時間（分）" fill="var(--color-accent)" />
+          <Bar dataKey="minutes" name="学習時間（分）" fill="var(--color-accent)" maxBarSize={55} />
         </BarChart>
       </ResponsiveContainer>
     </section>


### PR DESCRIPTION
## Summary
- Dashboardのカテゴリ別・月別学習時間グラフ（棒グラフ）の棒が太すぎるとの指摘を受け、`CategoryChart.tsx` / `MonthlyChart.tsx` の `<Bar>` に `maxBarSize={55}` を追加

Closes #64

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（37 tests passed）
- [x] `npm run build`
- [x] Docker Compose環境でブラウザ確認済み（ユーザー確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)