### PR TITLE
docs: README・テスト仕様書を最新のテスト実態に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ StudyLog/
 | 対象 | 件数 | フレームワーク |
 | --- | --- | --- |
 | Backend | 97件 | pytest |
-| Frontend | 17件（StarRating / Pagination / SearchForm） | Vitest + React Testing Library |
+| Frontend | 39件（16ファイル。共通UIコンポーネント、学習記録フォームコンポーネント、主要画面の表示確認） | Vitest + React Testing Library |
+
+テストの詳細（何をどのような観点でテストしているか）は [docs/テスト仕様書.md](docs/テスト仕様書.md) を参照。
 
 ```bash
 # Backend

--- a/docs/テスト仕様書.md
+++ b/docs/テスト仕様書.md
@@ -44,40 +44,38 @@ Backendのテストは、実際にFastAPIのTestClient経由でHTTPリクエス�
 - 単一ユーザー取得（正常系、存在しないIDで404、USER権限で403）
 - 他ユーザーの学習記録閲覧（論理削除済みの除外、ADMIN権限必須、存在しないユーザーIDで404、ADMIN自身のIDを指定した場合も動作すること）
 
-## Frontendテスト（Vitest + React Testing Library、3ファイル・17件）
+## Frontendテスト（Vitest + React Testing Library、16ファイル・39件）
 
-Phase 8で、仕様書が重点対象として挙げるコンポーネントに絞ってテストを追加しました。`StudyRecordForm`やページコンポーネント全体は意図的にスコープ外としています（詳細は次節）。
+Phase 8で重点コンポーネント（StarRating / Pagination / SearchForm）にテストを追加し、Phase 10（UI/UX改善）で共通UIコンポーネントと主要ページの表示確認テストを追加しました。個別のテストケースを網羅的に列挙するのではなく、カテゴリ単位で「何を」「どのような観点で」テストしているかをまとめます。
 
-### StarRating.test.tsx（4件）
+### 共通UIコンポーネント（Button / Card / FormField / PageHeader / Pagination、21件）
 
-- `value`に応じた★/☆の表示数が正しいこと
-- 選択中の星のみ`aria-checked`が`true`になること
-- 星をクリックすると、クリックした星の値で`onChange`が呼ばれること
-- `value=0`のとき全て☆で表示されること
+Phase 10-1で新設したデザインシステムの共通コンポーネント（`components/ui/`）と、Phase 8から継続する`Pagination`が対象です。
 
-### Pagination.test.tsx（8件）
+- **Button.test.tsx（4件）**：デフォルトでprimaryのスタイルが適用されること、`variant`指定で見た目が切り替わること、`disabled`指定時に無効化されること、クリックで`onClick`が呼ばれること
+- **Card.test.tsx（1件）**：`children`が表示されること
+- **FormField.test.tsx（3件）**：labelとchildrenが表示されること、`error`の有無で`ErrorMessage`の表示が切り替わること
+- **PageHeader.test.tsx（5件）**：`title`が表示されること、`description`/`action`の有無で表示が切り替わること
+- **Pagination.test.tsx（8件）**：`totalPages`が1以下・0のとき何も表示しないこと、先頭/最終/中間ページでの「前へ」「次へ」の有効/無効切り替え、現在のページ数の表示、クリックで`onPageChange`が正しいページ番号で呼ばれること
 
-- `totalPages`が1以下・0のとき何も表示されないこと
-- 先頭ページで「前へ」、最終ページで「次へ」がそれぞれ無効化されること
-- 中間ページでは両方のボタンが有効なこと
-- 現在のページ数の表示
-- 「前へ」「次へ」クリックで`onPageChange`が正しいページ番号で呼ばれること
+### 学習記録フォームコンポーネント（StarRating / SearchForm、9件）
 
-### SearchForm.test.tsx（5件）
+- **StarRating.test.tsx（4件）**：`value`に応じた★/☆の表示数、選択中の星のみ`aria-checked`が`true`になること、クリックで`onChange`が呼ばれること、`value=0`時の表示
+- **SearchForm.test.tsx（5件）**：マウント時のカテゴリ一覧の非同期取得・表示、カテゴリ取得失敗時のエラーメッセージ表示、検索条件送信時の値の受け渡し（未入力項目は`undefined`）、リセット時の入力クリアと`onSearch({})`呼び出し
 
-- マウント時にカテゴリ一覧を非同期取得し、選択肢として表示すること
-- カテゴリ取得に失敗した場合にエラーメッセージを表示すること
-- 検索条件の送信時、未入力項目が`undefined`として渡されること
-- 全項目入力時に入力値がそのまま渡されること
-- リセットボタンで入力項目がクリアされ、`onSearch({})`が呼ばれること
+### 主要画面の表示確認（Login / Register / Dashboard / Study Records / Admin、9件）
+
+Phase 10でUI/UXを刷新した各ページについて、API・カテゴリ一覧等をモックした上で、主要な見出し・入力欄・ボタン・リンクが正しく表示されることを確認しています。詳細なバリデーションロジックやAPI通信自体はBackend側のAPIテストでカバーされているため、Frontend側は表示確認レベルに留めています。
+
+- login/page.test.tsx、register/page.test.tsx：主要な見出し・入力欄・送信ボタン・遷移リンクの表示
+- dashboard/page.test.tsx：主要な見出し・サマリー・最近の学習記録の表示
+- study-records/page.test.tsx、study-records/new/page.test.tsx、study-records/[id]/edit/page.test.tsx：一覧・登録・編集画面の主要な見出し・フォーム要素の表示
+- admin/categories/page.test.tsx、admin/users/page.test.tsx、admin/users/[id]/study-records/page.test.tsx：管理者画面の主要な見出し・一覧・操作導線の表示
 
 ## テスト対象外の領域（現時点）
 
-以下はPhase 8のスコープ決定時に、意図的にテスト対象から除外しています。
-
-- **StudyRecordForm**：学習記録登録・編集フォーム本体。バリデーションロジックを内包するが、対象コンポーネントを重点3コンポーネント（StarRating / Pagination / SearchForm）に絞る方針としたため対象外
-- **ページコンポーネント**（`dashboard/page.tsx`等）：API通信・状態管理を含む結合的な性質が強く、Backend側のAPIテストで機能的なカバレッジは確保されているため対象外
 - **カバレッジ計測**：Vitest/pytestともにカバレッジツールは導入していない。数値目標を追うより重要コンポーネントを適切にテストする方針としている
+- **Rechartsの詳細な描画テスト**：ダッシュボードのグラフ（DailyChart / CategoryChart / MonthlyChart）はJSDOM環境でのSVG描画テストの相性が悪いため、グラフ自体の描画検証は行わず、ページの表示確認テストの範囲でカバーしている
 
 ## CIとの関係
 


### PR DESCRIPTION
## Summary
- README.md・docs/テスト仕様書.mdのFrontendテスト件数（旧: 3ファイル・17件）を、実測した最新値（16ファイル・39件）に更新
- テスト仕様書に、Phase 10で追加された13ファイルを「共通UIコンポーネント」「学習記録フォームコンポーネント」「主要画面の表示確認」の3カテゴリに整理して追記
- 「テスト対象外の領域」節から、実際にはテスト済みとなった「StudyRecordForm」「ページコンポーネント」の記載を削除
- READMEはテスト件数の概要のみとし、詳細はテスト仕様書に一本化（役割の重複を回避）

Backendのテスト件数（97件）は実測（`grep -c "def test_" tests/*.py`）と既存記載が一致していたため変更していない。

Closes #66

## Test plan
今回はドキュメントのみの変更（アプリケーションコード・テストコード・CI設定は無変更）だが、確認のため実行。
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（16 files / 39 tests passed）
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)