### PR TITLE
docs: 開発仕様書へPhase 10（Modern Dark Design System）を反映

### DIFF
--- a/docs/specifications/開発仕様書.md
+++ b/docs/specifications/開発仕様書.md
@@ -1,6 +1,6 @@
 # StudyLog 開発仕様書
 
-> このドキュメントはPhase 1〜9の実装・レビューを経て、実際のBackend/Frontend実装と整合するよう更新された正式な仕様書です。当初の仕様からの変更点には「（Phase 9で確認・追記）」等の注記を付けています。プロジェクトの目的や背景は [docs/要件定義.md](../要件定義.md) を、セットアップ手順や技術スタックは [README.md](../../README.md) を参照してください。
+> このドキュメントはPhase 1〜10の実装・レビューを経て、実際のBackend/Frontend実装と整合するよう更新された正式な仕様書です。当初の仕様からの変更点には「（Phase 9で確認・追記）」等の注記を付けています。プロジェクトの目的や背景は [docs/要件定義.md](../要件定義.md) を、セットアップ手順や技術スタックは [README.md](../../README.md) を参照してください。
 
 ## 1. プロジェクト概要
 
@@ -58,6 +58,7 @@ ITを学習しているユーザーが、自分の学習内容・学習時間・
 | CI | GitHub Actions（Phase 9で追加） |
 | API形式 | REST API |
 | データ形式 | JSON |
+| グラフ描画 | Recharts（Phase 10で追加。ダッシュボードの日別/カテゴリ別/月別学習時間グラフに使用） |
 
 ---
 
@@ -342,6 +343,8 @@ active_name = IF(is_deleted = 0, name, NULL)
 ---
 
 ## 11. 共通レイアウト
+
+Phase 10でModern Dark Design Systemを導入し、ヘッダー・サイドバーの配色をDesign Tokenに置き換えた（項目構成・ハンバーガーメニューの挙動自体は変更していない）。Design Tokenおよび共通UIコンポーネントの詳細は [47. Design System / 共通UIコンポーネント](#47-design-system--共通uiコンポーネント) を参照。
 
 ### ヘッダー
 
@@ -818,7 +821,8 @@ Git/GitHub運用ルール（Issue→Branch→実装→テスト→Commit→PR→
 | 6 | ダッシュボード | 完了 |
 | 7 | 管理者機能 | 完了 |
 | 8 | テスト・品質確認（Frontendテスト環境構築） | 完了 |
-| 9 | 最終確認（総合レビュー・ドキュメント整備・CI導入） | 進行中 |
+| 9 | 最終確認（総合レビュー・ドキュメント整備・CI導入） | 完了 |
+| 10 | UI/UX改善（Modern Dark Design System導入） | 完了 |
 
 ---
 
@@ -843,3 +847,44 @@ Git/GitHub運用ルール（Issue→Branch→実装→テスト→Commit→PR→
 - Lint / Type Check / Buildが成功する
 - mainへの直接pushができない
 - Issue → Branch → Commit → PR → MergeのGitフローを守る
+
+---
+
+## 47. Design System / 共通UIコンポーネント
+
+Phase 10で、GitHub / Vercel / Linearのようなダークモード中心・エンジニア向けのUIを目指し、Modern Dark Design Systemを導入した。ライト/ダークの切り替え機能は設けず、ダークテーマを標準（固定）テーマとする。
+
+### 47.1 Design Token
+
+`frontend/app/globals.css`の`:root`に、色・角丸・シャドウ・余白のCSS変数（デザイントークン）を定義し、個別ファイルへの色のハードコードを避けている。
+
+| カテゴリ | トークン例 | 用途 |
+| --- | --- | --- |
+| Color - Surface | `--color-bg` / `--color-surface` / `--color-surface-hover` / `--color-border` | 背景・カード・境界線 |
+| Color - Text | `--color-text-primary` / `--color-text-secondary` / `--color-text-muted` | 文字色の階層表現 |
+| Color - Accent | `--color-accent` / `--color-accent-hover` | 主要アクション・リンクの強調色（Indigo系） |
+| Color - Status | `--color-success` / `--color-warning` / `--color-danger` / `--color-danger-hover` | 成功・警告・危険操作の状態表現 |
+| Radius | `--radius-sm` / `--radius-md` / `--radius-lg` | 角丸の統一 |
+| Shadow | `--shadow-sm` / `--shadow-md` | 立体感の統一 |
+| Spacing | `--spacing-xs`〜`--spacing-xl` | 余白の統一 |
+
+`input` / `select` / `textarea`の基本スタイル（背景・境界線・角丸・パディング・フォーカス時のアウトライン）もグローバルに定義し、フォーム部品の見た目を個別実装に頼らず統一している。
+
+### 47.2 共通UIコンポーネント（`frontend/components/ui/`）
+
+過剰な抽象化を避け、複数画面で明確に再利用される4つのコンポーネントのみを共通化した。
+
+| コンポーネント | 役割 | 設計方針 |
+| --- | --- | --- |
+| `Button` | ボタン・ボタン風リンクの見た目統一 | `variant`（`primary` / `secondary` / `danger`）のみを持つ薄いラッパー。`primary`は登録・保存・追加・検索など主要操作、`secondary`は編集・キャンセル・リセットなど中立操作、`danger`は削除など危険操作に用いる。`ButtonHTMLAttributes`をそのまま継承し、`type`・`disabled`・`onClick`等は素の`<button>`と同じ書き方で使える |
+| `Card` | セクションを囲むコンテナ | `children`と`className`のみを受け取る最小構成。padding等のvariantは設けず、必要になった時点で拡張する方針 |
+| `FormField` | `label` + 入力欄 + エラーメッセージの配置統一 | `label` / `htmlFor` / `error` / `children`を受け取り、`input`・`select`・`textarea`はすべて`children`としてそのまま渡す。入力要素自体を万能コンポーネント化せず、配置とラベル・エラー表示の統一のみを担当する。`role="radiogroup"`のような特殊なUI（理解度のStarRating）には無理に適用せず、個別にCSSで見た目を揃える |
+| `PageHeader` | ページタイトル・説明文・アクションボタンの配置統一 | `title`（必須）/ `description`（任意）/ `action`（任意、`ReactNode`）で構成し、ページごとに過不足なく使える |
+
+### 47.3 Tableを共通コンポーネント化しなかった理由
+
+一覧画面（学習記録一覧・カテゴリ管理・ユーザー一覧・他ユーザー学習記録）は画面ごとにカラム構成・操作列の有無が大きく異なるため、無理に共通Tableコンポーネントを作らず、各ページで素の`<table>`をそのまま使用し、CSS Module（ヘッダー行・罫線・セルpadding・行hover・文字色）でModern Darkの見た目のみを統一する方針を採った。「将来使うかもしれない」という理由での抽象化は行わず、実際に複数画面で完全に同じ構造が必要になった場合のみ共通化を検討することとした。同様の理由で、Modal・Navigation（既存のHeader/Sidebarで十分機能している）も共通コンポーネント化していない。
+
+### 47.4 Rechartsのデザイン統一
+
+ダッシュボードのグラフ（`DailyChart` / `CategoryChart` / `MonthlyChart`）は、色をハードコードせず、Rechartsの`fill` / `stroke`等の属性にCSS変数を文字列として直接渡す方式（例：`fill="var(--color-accent)"`）でDesign Tokenと連動させている。Tooltipの背景・境界線・文字色も同様にCSS変数で指定し、ダークテーマに合わせて統一した。棒グラフは`maxBarSize`で棒の最大幅を制限し、データ件数が少ない場合でも棒が太くなりすぎないようにしている。


### PR DESCRIPTION
## Summary
- 開発フェーズ表（44節）にPhase 10を追加、Phase 9を「完了」に更新
- 技術構成表（2節）にRecharts（グラフ描画）を追加
- 共通レイアウト節（11節）に、Modern Dark Design System導入と新設セクションへの参照を追記
- 新設「47. Design System / 共通UIコンポーネント」節を追加
  - Design Token（色・角丸・シャドウ・余白）の一覧と用途
  - 共通UIコンポーネント（Button / Card / FormField / PageHeader）の役割・設計方針
  - Tableを共通コンポーネント化しなかった理由
  - Rechartsのデザイン統一方法（CSS変数をfill/stroke属性に直接指定）
- 冒頭の「Phase 1〜9」表記を「Phase 1〜10」に更新

すべて`frontend/app/globals.css`・`frontend/components/ui/*`・各Chartコンポーネントの実装内容を確認した上で記載している。

Closes #68

## Test plan
今回はドキュメントのみの変更（アプリケーションコードは無変更）だが、確認のため実行。
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run test`（16 files / 39 tests passed）
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)