### PR TITLE
AWS EC2へのTerraformデプロイ構成を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,13 @@ venv/
 .ruff_cache/
 
 .DS_Store
+
+# Terraform
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup
+terraform/terraform.tfvars
+terraform/*.pem
+
+terraform/tfplan

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN chmod +x docker-entrypoint.prod.sh
+
+ENTRYPOINT ["./docker-entrypoint.prod.sh"]

--- a/backend/docker-entrypoint.prod.sh
+++ b/backend/docker-entrypoint.prod.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+alembic upgrade head
+python -m app.db.seed
+
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,52 @@
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prod
+      args:
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.prod
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: mysql+pymysql://studylog:studylog@db:3306/studylog
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      COOKIE_SECURE: "false"
+      TIMEZONE: Asia/Tokyo
+      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS}
+      SEED_ADMIN_USERNAME: ${SEED_ADMIN_USERNAME:-admin}
+      SEED_ADMIN_PASSWORD: ${SEED_ADMIN_PASSWORD}
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    command: --default-time-zone=+09:00
+    environment:
+      TZ: Asia/Tokyo
+      MYSQL_DATABASE: studylog
+      MYSQL_USER: studylog
+      MYSQL_PASSWORD: studylog
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,0 +1,28 @@
+FROM node:22-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+
+RUN npm run build
+
+FROM node:22-slim
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/package.json /app/package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.ts ./next.config.ts
+
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,124 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "random_password" "jwt_secret" {
+  count   = var.jwt_secret_key == "" ? 1 : 0
+  length  = 48
+  special = false
+}
+
+resource "random_password" "admin_password" {
+  count   = var.seed_admin_password == "" ? 1 : 0
+  length  = 20
+  special = true
+}
+
+locals {
+  jwt_secret_key       = var.jwt_secret_key != "" ? var.jwt_secret_key : random_password.jwt_secret[0].result
+  seed_admin_password  = var.seed_admin_password != "" ? var.seed_admin_password : random_password.admin_password[0].result
+}
+
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "this" {
+  key_name   = "studylog-key"
+  public_key = tls_private_key.ssh.public_key_openssh
+}
+
+resource "local_sensitive_file" "private_key" {
+  filename        = "${path.module}/studylog-key.pem"
+  content         = tls_private_key.ssh.private_key_pem
+  file_permission = "0400"
+}
+
+resource "aws_security_group" "this" {
+  name        = "studylog-sg"
+  description = "StudyLog app security group"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.ssh_allowed_cidr]
+  }
+
+  ingress {
+    description = "Frontend"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Backend API"
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "studylog-sg"
+  }
+}
+
+resource "aws_instance" "app" {
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type           = var.instance_type
+  subnet_id               = data.aws_subnets.default.ids[0]
+  vpc_security_group_ids  = [aws_security_group.this.id]
+  key_name                = aws_key_pair.this.key_name
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+  }
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    repo_url             = var.repo_url
+    repo_branch           = var.repo_branch
+    jwt_secret_key         = local.jwt_secret_key
+    seed_admin_username    = var.seed_admin_username
+    seed_admin_password    = local.seed_admin_password
+  })
+
+  tags = {
+    Name = "studylog-app"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,28 @@
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance"
+  value       = aws_instance.app.public_ip
+}
+
+output "frontend_url" {
+  description = "URL to access the frontend"
+  value       = "http://${aws_instance.app.public_ip}:3000"
+}
+
+output "backend_url" {
+  description = "URL to access the backend API"
+  value       = "http://${aws_instance.app.public_ip}:8000"
+}
+
+output "ssh_command" {
+  description = "SSH command to connect to the instance"
+  value       = "ssh -i ${path.module}/studylog-key.pem ec2-user@${aws_instance.app.public_ip}"
+}
+
+output "seed_admin_username" {
+  value = var.seed_admin_username
+}
+
+output "seed_admin_password" {
+  value     = local.seed_admin_password
+  sensitive = true
+}

--- a/terraform/user_data.sh.tpl
+++ b/terraform/user_data.sh.tpl
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -eux
+
+dnf update -y
+dnf install -y docker git
+
+systemctl enable docker
+systemctl start docker
+usermod -aG docker ec2-user
+
+DOCKER_COMPOSE_VERSION="v2.29.7"
+curl -SL "https://github.com/docker/compose/releases/download/$${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+  -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+ln -sf /usr/local/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose || true
+
+cd /home/ec2-user
+git clone --branch ${repo_branch} --single-branch ${repo_url} app
+cd app
+
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+PUBLIC_IP=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
+
+cat > .env <<EOF
+JWT_SECRET_KEY=${jwt_secret_key}
+SEED_ADMIN_USERNAME=${seed_admin_username}
+SEED_ADMIN_PASSWORD=${seed_admin_password}
+NEXT_PUBLIC_API_BASE_URL=http://$${PUBLIC_IP}:8000
+CORS_ALLOW_ORIGINS=["http://$${PUBLIC_IP}:3000"]
+EOF
+
+chown -R ec2-user:ec2-user /home/ec2-user/app
+
+/usr/local/bin/docker-compose -f docker-compose.prod.yml up -d --build

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,49 @@
+variable "aws_region" {
+  description = "AWS region to deploy into"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type (free tier eligible)"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "repo_url" {
+  description = "Git repository URL to clone on the instance"
+  type        = string
+  default     = "https://github.com/329nh329-ops/StudyLog.git"
+}
+
+variable "repo_branch" {
+  description = "Git branch to deploy"
+  type        = string
+  default     = "main"
+}
+
+variable "ssh_allowed_cidr" {
+  description = "CIDR block allowed to SSH into the instance"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "jwt_secret_key" {
+  description = "JWT secret key for the backend (leave empty to auto-generate)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "seed_admin_username" {
+  description = "Seed admin username"
+  type        = string
+  default     = "admin"
+}
+
+variable "seed_admin_password" {
+  description = "Seed admin password (leave empty to auto-generate)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}


### PR DESCRIPTION
## Summary
- 個人利用・スクール課題用途で、StudyLogをAWS EC2 1台（t3.micro, Docker Compose）にTerraformでデプロイする構成を追加
- 本番相当の起動方式（Next.js production build/start、FastAPIはreloadなし、起動時にalembic migration + admin seed実行）を採用
- 既存の開発用docker-compose.ymlとは分離し、docker-compose.prod.yml / Dockerfile.prodを新規追加
- 独自ドメイン・HTTPSは対象外（パブリックIP + HTTP）

## 変更内容
- `terraform/`: EC2, セキュリティグループ, キーペアをTerraformで定義
- `backend/Dockerfile.prod`, `backend/docker-entrypoint.prod.sh`: reloadなしのuvicorn起動 + 起動時migration/seed
- `frontend/Dockerfile.prod`: マルチステージビルドでNext.js production build/start
- `docker-compose.prod.yml`: 本番用compose定義（DBポートは非公開）

Closes #74

## Test plan
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run test` / `npm run build`（frontend、全てpass）
- [x] ローカルで`docker compose -f docker-compose.prod.yml up`を実行し、DB healthy・backend `/health`・frontend `/login`が200になることを確認
- [x] `terraform validate` / `terraform plan`成功
- [ ] EC2上での実機起動確認（本PRマージ後に実施）
- [ ] CI（backend/frontend）成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)