### PR TITLE
AWSデプロイ方式をローカルビルド方式に一本化しドキュメント化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ terraform/terraform.tfvars
 terraform/*.pem
 
 terraform/tfplan
+
+# Deploy (production secrets)
+deploy/env.prod.local
+deploy/*.pem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@
 4. テストを実行する
    - Backend: `pytest tests/ -v`、`ruff check .`、`ruff format --check .`
    - Frontend: `npm run lint`、`npx tsc --noEmit`、`npm run test`、`npm run build`
+   - Terraform（`terraform/`配下を変更した場合）: [Terraform品質チェック](#terraform品質チェック)を参照
 5. コミットする
 6. Pull Requestを作成する（対応するIssueへの参照を含める。例：`Closes #12`）
 7. GitHub Actions（CI）の`backend`・`frontend`両ジョブが成功することを確認する
@@ -28,6 +29,23 @@
 ### Pull Requestのマージ
 
 Pull Requestのマージは、CIの成功を確認した上で、必ずユーザーの確認・承認を得てから行う。Claude Codeが自身の判断でマージを実行しない。
+
+## Terraform品質チェック
+
+`terraform/`配下（AWSインフラ構成）を変更した場合、コミット前に以下を実施する。
+
+1. `terraform fmt -recursive` でフォーマットを統一する
+2. `terraform validate` で構文・設定の妥当性を確認する
+3. `terraform plan` で変更内容を確認する
+   - 意図しないリソースの作成・変更・削除がないか確認する
+   - 特にEC2インスタンスなど課金が発生するリソースが、意図せず新規作成・再作成されていないか確認する
+4. 機密情報（AWSアクセスキー、SSH秘密鍵、DBパスワード、JWTシークレットなど）がTerraformコード（`.tf`）や変数ファイル（`.tfvars`等）に直接書かれていないか確認する
+   - `terraform.tfstate`にはリソース作成時の機密情報が平文で残るため、Gitに含めない（`.gitignore`で除外済み）
+   - アプリケーションのシークレット（JWT_SECRET_KEY等）はTerraformで管理せず、`deploy/`配下のデプロイ手順・環境変数ファイルで扱う
+5. Security Groupの変更がある場合、不要なポートを外部公開していないか確認する
+   - 想定外のポート（特にDB用の3306番など）が`0.0.0.0/0`に対して開いていないか確認する
+
+これらはCIでは自動実行されないため、`terraform/`配下を変更したPRでは、実施結果をPRの説明やコメントに記載する。
 
 ## エラー・不具合調査の記録
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ ITを学習しているユーザーが、学習内容・学習時間・理解度
 - [技術スタック](#技術スタック)
 - [技術選定理由](#技術選定理由)
 - [アーキテクチャ](#アーキテクチャ)
+- [本番デプロイ構成（AWS）](#本番デプロイ構成aws)
 - [ディレクトリ構成](#ディレクトリ構成)
 - [セキュリティ](#セキュリティ)
 - [テスト](#テスト)
@@ -78,6 +79,7 @@ ITを学習しているユーザーが、学習内容・学習時間・理解度
 | MySQL | 8.0（`docker-compose.yml`） |
 | Docker Compose | frontend / backend / db の3サービス構成 |
 | CI | GitHub Actions（PR時に自動実行） |
+| クラウド（本番デプロイ検証用） | AWS EC2（t3.micro） / Terraform（`terraform/`） |
 
 ## 技術選定理由
 
@@ -135,6 +137,59 @@ Next.jsのroute group（`(protected)`）で保護ページをまとめ、`(prote
 - JWTは**HttpOnly Cookie**に保存（有効期限1時間）
 - CSRF対策として**Double Submit Cookie方式**を採用（`csrf_token`Cookie + `X-CSRF-Token`ヘッダー）
 - 状態変更を伴うAPI（POST/PUT/DELETE）はCSRF検証必須
+
+## 本番デプロイ構成（AWS）
+
+個人利用・学習目的での実機デプロイ検証用に、AWS EC2 1台上にDocker Composeで本番相当の環境を構築できる構成を用意しています。独自ドメイン・HTTPSは対象外（パブリックIP + HTTPでのアクセス）です。
+
+```mermaid
+flowchart LR
+    User["利用者のブラウザ"] -->|HTTP :3000| EC2
+
+    subgraph EC2["EC2 (t3.micro) - Amazon Linux 2023"]
+        direction LR
+        FrontendC["frontendコンテナ<br/>Next.js production server<br/>:3000"]
+        BackendC["backendコンテナ<br/>FastAPI (uvicorn)<br/>:8000"]
+        DBC[("dbコンテナ<br/>MySQL<br/>:3306 (外部非公開)")]
+
+        FrontendC -->|REST API / JSON| BackendC
+        BackendC -->|SQLAlchemy| DBC
+    end
+
+    User -->|HTTP :8000| BackendC
+```
+
+- **EC2 1台構成**：frontend / backend / MySQLの3コンテナをDocker Composeで同一インスタンス上に同居させるシンプルな構成。個人利用の学習目的であり、可用性よりコストと構成のシンプルさを優先しています
+- **外部からのアクセス経路**：ブラウザ→EC2のパブリックIP（ポート3000でfrontend、8000でbackend API）のみ。SSH（22番）は管理用に別途開放
+- **MySQLは外部非公開**：`db`コンテナの3306番ポートはDocker Composeのネットワーク内でのみ到達可能で、Security Groupでも公開していません。DBへの外部からの直接アクセス経路はありません
+- **Security Group**：22（SSH）/ 3000（frontend）/ 8000（backend）のみを許可し、それ以外のインバウンドは許可していません
+
+### Terraformとデプロイスクリプトの責務分担
+
+インフラ構築とアプリケーションのデプロイは責務を分離しています。
+
+| 領域 | 担当 | 内容 |
+| --- | --- | --- |
+| AWSインフラの構築 | `terraform/` | EC2インスタンス、Security Group、SSHキーペアの作成、EC2上へのDocker / Docker Compose本体のインストール（起動時の`user_data`） |
+| アプリケーションのデプロイ | `deploy/deploy.sh` | 本番用Dockerイメージのbuild・EC2への転送・起動 |
+
+Terraformは「インスタンスがDockerを実行できる状態を作る」ところまでを担当し、アプリケーションのコンテナ自体はTerraformの管理対象に含めていません。
+
+### アプリケーションのデプロイ方式：ローカルビルド＋イメージ転送
+
+実機検証の結果、EC2上（t3.micro、メモリ1GB）でNext.jsの`npm run build`を直接実行すると、メモリ不足によりOSごと応答不能になる問題が確認されました（詳細は[docs/incidents/2026-09-03-ec2-build-oom.md](docs/incidents/2026-09-03-ec2-build-oom.md)）。
+
+この問題を避けるため、Dockerイメージのbuildはローカル(Mac)で行い、完成したイメージだけをEC2に転送する方式を採用しています。EC2側で発生する処理はコンテナの実行のみです。
+
+```mermaid
+flowchart LR
+    Build["ローカル(Mac)<br/>docker build (production)"] --> Save["docker save<br/>+ gzip"]
+    Save --> Transfer["scp転送"]
+    Transfer --> Load["EC2上で<br/>docker load"]
+    Load --> Up["docker compose up<br/>(コンテナ実行のみ)"]
+```
+
+`deploy/deploy.sh`がこの一連の流れを自動化しています。使い方は[deploy/deploy.sh](deploy/deploy.sh)のコメントを参照してください。
 
 ## ディレクトリ構成
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# StudyLog本番デプロイスクリプト
+#
+# ローカル(Mac)でDocker本番イメージをbuildし、EC2へ転送してDocker Composeで起動する。
+# t3.micro(メモリ1GB)ではNext.jsのproduction buildがメモリ不足を起こすため、
+# EC2上ではbuildを行わず、コンテナ実行のみを行う方式を採用している。
+# 詳細な経緯は docs/incidents/ を参照。
+#
+# 使い方:
+#   ./deploy/deploy.sh <EC2パブリックIP> <SSH秘密鍵パス> <.envファイルパス>
+#
+# .envファイルには以下を定義すること（deploy/env.prod.example参照）:
+#   JWT_SECRET_KEY, SEED_ADMIN_USERNAME, SEED_ADMIN_PASSWORD,
+#   NEXT_PUBLIC_API_BASE_URL, CORS_ALLOW_ORIGINS
+
+set -euo pipefail
+
+EC2_HOST="${1:?EC2パブリックIPを指定してください}"
+SSH_KEY="${2:?SSH秘密鍵のパスを指定してください}"
+ENV_FILE="${3:?本番用.envファイルのパスを指定してください}"
+
+SSH_USER="ec2-user"
+REMOTE_APP_DIR="/home/ec2-user/app"
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+
+echo "==> [1/6] backendイメージをbuild"
+docker build --platform linux/amd64 \
+  -f "$PROJECT_ROOT/backend/Dockerfile.prod" \
+  -t studylog-backend:prod \
+  "$PROJECT_ROOT/backend"
+
+echo "==> [2/6] frontendイメージをbuild"
+NEXT_PUBLIC_API_BASE_URL="$(grep -E '^NEXT_PUBLIC_API_BASE_URL=' "$ENV_FILE" | cut -d= -f2-)"
+docker build --platform linux/amd64 \
+  -f "$PROJECT_ROOT/frontend/Dockerfile.prod" \
+  --build-arg NEXT_PUBLIC_API_BASE_URL="$NEXT_PUBLIC_API_BASE_URL" \
+  -t studylog-frontend:prod \
+  "$PROJECT_ROOT/frontend"
+
+echo "==> [3/6] イメージをtar.gzにexport"
+docker save studylog-backend:prod | gzip > "$WORK_DIR/backend.tar.gz"
+docker save studylog-frontend:prod | gzip > "$WORK_DIR/frontend.tar.gz"
+
+echo "==> [4/6] EC2へ転送"
+ssh "${SSH_OPTS[@]}" "$SSH_USER@$EC2_HOST" "mkdir -p $REMOTE_APP_DIR"
+scp "${SSH_OPTS[@]}" \
+  "$WORK_DIR/backend.tar.gz" \
+  "$WORK_DIR/frontend.tar.gz" \
+  "$PROJECT_ROOT/docker-compose.prod.yml" \
+  "$ENV_FILE" \
+  "$SSH_USER@$EC2_HOST:$REMOTE_APP_DIR/"
+ssh "${SSH_OPTS[@]}" "$SSH_USER@$EC2_HOST" \
+  "mv $REMOTE_APP_DIR/$(basename "$ENV_FILE") $REMOTE_APP_DIR/.env"
+
+echo "==> [5/6] EC2上でイメージをload"
+ssh "${SSH_OPTS[@]}" "$SSH_USER@$EC2_HOST" "
+  sudo docker load -i $REMOTE_APP_DIR/backend.tar.gz &&
+  sudo docker load -i $REMOTE_APP_DIR/frontend.tar.gz &&
+  rm -f $REMOTE_APP_DIR/backend.tar.gz $REMOTE_APP_DIR/frontend.tar.gz
+"
+
+echo "==> [6/6] Docker Composeで起動"
+ssh "${SSH_OPTS[@]}" "$SSH_USER@$EC2_HOST" "
+  cd $REMOTE_APP_DIR &&
+  sudo /usr/local/bin/docker-compose -f docker-compose.prod.yml up -d
+"
+
+echo "==> デプロイ完了"
+echo "Frontend: http://$EC2_HOST:3000"
+echo "Backend:  http://$EC2_HOST:8000/health"

--- a/deploy/env.prod.example
+++ b/deploy/env.prod.example
@@ -1,0 +1,15 @@
+# deploy/deploy.sh に渡す本番用.envファイルのサンプル。
+# このファイルをコピーして値を設定し、Gitにはコミットしないこと。
+#
+#   cp deploy/env.prod.example deploy/env.prod.local
+#
+# JWT_SECRET_KEY, SEED_ADMIN_PASSWORDはランダムな値を生成して設定する。
+#   openssl rand -hex 32
+
+JWT_SECRET_KEY=
+SEED_ADMIN_USERNAME=admin
+SEED_ADMIN_PASSWORD=
+
+# EC2のパブリックIPに合わせて設定する
+NEXT_PUBLIC_API_BASE_URL=http://<EC2_PUBLIC_IP>:8000
+CORS_ALLOW_ORIGINS=["http://<EC2_PUBLIC_IP>:3000"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,6 @@
 services:
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile.prod
-      args:
-        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
+    image: studylog-frontend:prod
     restart: unless-stopped
     ports:
       - "3000:3000"
@@ -12,9 +8,7 @@ services:
       - backend
 
   backend:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile.prod
+    image: studylog-backend:prod
     restart: unless-stopped
     ports:
       - "8000:8000"

--- a/docs/incidents/2026-09-03-ec2-build-oom.md
+++ b/docs/incidents/2026-09-03-ec2-build-oom.md
@@ -1,0 +1,34 @@
+# 2026-09-03 EC2(t3.micro)上でのDocker本番buildによるメモリ不足・SSH不通
+
+## 発生した現象
+
+AWS EC2（t3.micro, メモリ1GB）上に、Terraformの`user_data`経由でリポジトリをclone → `docker compose -f docker-compose.prod.yml up -d --build`を実行し、frontend（Next.js production build）・backend・MySQLをデプロイしようとした。
+
+- `docker compose ... --build`の実行中、コマンドが応答しないままタイムアウトした
+- その後、同インスタンスへのSSH接続を試みたところ「Connection timed out during banner exchange」で接続不可になった
+- AWSコンソール（`describe-instance-status`）上ではインスタンスのステータスチェックは`ok`で、CPU使用率も張り付いてはいなかった
+
+## 調査方法
+
+1. `aws ec2 get-console-output`でシリアルコンソールログを取得し、カーネルパニックなど致命的なクラッシュが起きていないか確認した
+   - ログの末尾はカーネルパニックではなく、Dockerコンテナのネットワークインターフェース（veth）が生成・削除を繰り返すログで途切れていた
+   - これはコンテナが起動→クラッシュ→`restart`ポリシーによる再起動、を繰り返すパターンに一致する
+2. 一度`stop`→`start`でインスタンスを再起動し、正常にSSH接続できることを確認した
+3. 再起動直後の`free -h`でメモリ状況を確認したところ、911MB中609MB空きとクリーンな状態だった
+4. その状態から`docker-compose.prod.yml`のbuild方式で起動を試みる代わりに、ローカル(Mac)でビルド済みのイメージを`docker load`で読み込ませてコンテナを起動したところ、正常に起動できた
+5. 起動後の`free -h`では911MB中674MB使用、空き62MBまで逼迫していることを確認した（実行時だけでもメモリ使用量にほぼ余裕がない）
+
+## わかったこと
+
+- t3.micro（メモリ1GB、スワップ領域なし）上で`npm run build`（Next.jsのproduction build、TypeScriptの型チェックを含む）を実行すると、メモリを使い切りOOM killerがプロセスを強制終了させる。この際sshdも巻き込まれ、SSH接続自体が不能になることが実機で確認できた
+- ステータスチェックが`ok`のままSSHだけが不通になる、という一見矛盾した状態はOOMの典型的な症状であり、CPU使用率だけでは異常を検知できない
+- インスタンスの`terminate`（破棄）ではなく`stop`/`start`（再起動）だけで復旧できた。AWSリソースの再作成は不要だった
+- ビルドを伴わずコンテナを実行するだけであれば、メモリはまだ逼迫するものの（空き62MB）動作は安定した
+
+## 対応内容
+
+EC2上ではDockerイメージのbuildを一切行わず、ローカル(Mac)で本番用イメージをbuildし、`docker save` → `scp` → `docker load`でEC2に転送してコンテナを起動する方式に変更した。
+
+この対応により、EC2側の負荷はコンテナの実行のみとなり、実機での動作を確認できた。恒久対応として、この方式を正式なデプロイ手順として`deploy/deploy.sh`にスクリプト化し、`docker-compose.prod.yml`からもbuild定義を削除した。
+
+なお、メモリの逼迫（空き62MB）は解消されていないため、今後アプリケーションの規模が大きくなった場合はインスタンスタイプの見直しが必要になる可能性がある。

--- a/docs/specifications/開発仕様書.md
+++ b/docs/specifications/開発仕様書.md
@@ -77,14 +77,34 @@ flowchart LR
 Docker Compose
 │
 ├── frontend
-│   └── Next.js :3000
+│   └── Next.js :3000 (npm run dev)
 │
 ├── backend
-│   └── FastAPI :8000
+│   └── FastAPI :8000 (uvicorn --reload)
 │
 └── db
-    └── MySQL :3306
+    └── MySQL :3306（ホストにも公開）
 ```
+
+### 3.1 本番環境（AWSデプロイ検証）との違い
+
+学習目的の実機デプロイ検証として、AWS EC2 1台上に本番相当の構成を構築できるようにしている。詳細な構成図・アクセス経路は[README.mdの本番デプロイ構成（AWS）](../../README.md#本番デプロイ構成aws)を参照。開発環境との主な違いは以下の通り。
+
+| 項目 | 開発環境 | 本番環境（AWS） |
+| --- | --- | --- |
+| frontendの起動方式 | `npm run dev`（開発サーバー） | `npm run build` → `npm run start`（本番ビルド） |
+| backendの起動方式 | `uvicorn --reload` | `uvicorn`（reloadなし）。起動時に`alembic upgrade head`とadminシード投入を実行 |
+| MySQLの3306番ポート | ホストに公開（ローカルからDB直接接続可能） | 非公開（コンテナ間ネットワークのみ） |
+| Dockerイメージのbuild場所 | ローカル環境（Docker Compose） | ローカル(Mac)。EC2上ではbuildを行わない |
+| インフラ構築方法 | Docker Composeを手元で起動 | Terraformで EC2 / Security Group / SSHキーペアを構築 |
+
+### 3.2 設計判断：EC2上でのbuildを採用しなかった理由
+
+当初はEC2上で`docker compose up --build`を実行し、git clone直後にビルド・起動まで完結させる方式を想定していた。しかし実機検証の結果、EC2インスタンス（t3.micro、メモリ1GB）上でNext.jsの本番ビルドを実行するとメモリ不足でOSごと応答不能になることが判明した（調査の詳細は[docs/incidents/2026-09-03-ec2-build-oom.md](../incidents/2026-09-03-ec2-build-oom.md)）。
+
+このため、Dockerイメージのbuildはローカル(Mac)で行い、`docker save` → `scp` → `docker load`でEC2にイメージを転送してコンテナを起動する方式に変更した。EC2側で発生する処理はコンテナの実行のみとなり、この方式で実機起動を確認できている。
+
+この判断に伴い、Terraformが担うのは「EC2がDockerを実行できる状態を作るところまで」とし、アプリケーションのビルド・転送・起動は`deploy/deploy.sh`（デプロイスクリプト）の責務として分離した。
 
 ---
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,23 +24,6 @@ data "aws_ami" "amazon_linux" {
   }
 }
 
-resource "random_password" "jwt_secret" {
-  count   = var.jwt_secret_key == "" ? 1 : 0
-  length  = 48
-  special = false
-}
-
-resource "random_password" "admin_password" {
-  count   = var.seed_admin_password == "" ? 1 : 0
-  length  = 20
-  special = true
-}
-
-locals {
-  jwt_secret_key       = var.jwt_secret_key != "" ? var.jwt_secret_key : random_password.jwt_secret[0].result
-  seed_admin_password  = var.seed_admin_password != "" ? var.seed_admin_password : random_password.admin_password[0].result
-}
-
 resource "tls_private_key" "ssh" {
   algorithm = "RSA"
   rsa_bits  = 4096
@@ -100,23 +83,17 @@ resource "aws_security_group" "this" {
 
 resource "aws_instance" "app" {
   ami                    = data.aws_ami.amazon_linux.id
-  instance_type           = var.instance_type
-  subnet_id               = data.aws_subnets.default.ids[0]
-  vpc_security_group_ids  = [aws_security_group.this.id]
-  key_name                = aws_key_pair.this.key_name
+  instance_type          = var.instance_type
+  subnet_id              = data.aws_subnets.default.ids[0]
+  vpc_security_group_ids = [aws_security_group.this.id]
+  key_name               = aws_key_pair.this.key_name
 
   root_block_device {
     volume_type = "gp3"
     volume_size = 20
   }
 
-  user_data = templatefile("${path.module}/user_data.sh.tpl", {
-    repo_url             = var.repo_url
-    repo_branch           = var.repo_branch
-    jwt_secret_key         = local.jwt_secret_key
-    seed_admin_username    = var.seed_admin_username
-    seed_admin_password    = local.seed_admin_password
-  })
+  user_data = file("${path.module}/user_data.sh.tpl")
 
   tags = {
     Name = "studylog-app"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,12 +17,3 @@ output "ssh_command" {
   description = "SSH command to connect to the instance"
   value       = "ssh -i ${path.module}/studylog-key.pem ec2-user@${aws_instance.app.public_ip}"
 }
-
-output "seed_admin_username" {
-  value = var.seed_admin_username
-}
-
-output "seed_admin_password" {
-  value     = local.seed_admin_password
-  sensitive = true
-}

--- a/terraform/user_data.sh.tpl
+++ b/terraform/user_data.sh.tpl
@@ -2,7 +2,7 @@
 set -eux
 
 dnf update -y
-dnf install -y docker git
+dnf install -y docker
 
 systemctl enable docker
 systemctl start docker
@@ -14,21 +14,5 @@ curl -SL "https://github.com/docker/compose/releases/download/$${DOCKER_COMPOSE_
 chmod +x /usr/local/bin/docker-compose
 ln -sf /usr/local/bin/docker-compose /usr/libexec/docker/cli-plugins/docker-compose || true
 
-cd /home/ec2-user
-git clone --branch ${repo_branch} --single-branch ${repo_url} app
-cd app
-
-TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
-PUBLIC_IP=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
-
-cat > .env <<EOF
-JWT_SECRET_KEY=${jwt_secret_key}
-SEED_ADMIN_USERNAME=${seed_admin_username}
-SEED_ADMIN_PASSWORD=${seed_admin_password}
-NEXT_PUBLIC_API_BASE_URL=http://$${PUBLIC_IP}:8000
-CORS_ALLOW_ORIGINS=["http://$${PUBLIC_IP}:3000"]
-EOF
-
+mkdir -p /home/ec2-user/app
 chown -R ec2-user:ec2-user /home/ec2-user/app
-
-/usr/local/bin/docker-compose -f docker-compose.prod.yml up -d --build

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,45 +5,13 @@ variable "aws_region" {
 }
 
 variable "instance_type" {
-  description = "EC2 instance type (free tier eligible)"
+  description = "EC2 instance type"
   type        = string
   default     = "t3.micro"
-}
-
-variable "repo_url" {
-  description = "Git repository URL to clone on the instance"
-  type        = string
-  default     = "https://github.com/329nh329-ops/StudyLog.git"
-}
-
-variable "repo_branch" {
-  description = "Git branch to deploy"
-  type        = string
-  default     = "main"
 }
 
 variable "ssh_allowed_cidr" {
   description = "CIDR block allowed to SSH into the instance"
   type        = string
   default     = "0.0.0.0/0"
-}
-
-variable "jwt_secret_key" {
-  description = "JWT secret key for the backend (leave empty to auto-generate)"
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "seed_admin_username" {
-  description = "Seed admin username"
-  type        = string
-  default     = "admin"
-}
-
-variable "seed_admin_password" {
-  description = "Seed admin password (leave empty to auto-generate)"
-  type        = string
-  default     = ""
-  sensitive   = true
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.6"
-    }
     local = {
       source  = "hashicorp/local"
       version = "~> 2.5"


### PR DESCRIPTION
## Summary
- #74 の実機デプロイ検証で、t3.micro(メモリ1GB)上でNext.jsのproduction buildを実行するとメモリ不足によりSSHが不通になる問題が判明した
- EC2上でDockerイメージをbuildする方式を廃止し、ローカル(Mac)でbuildしたイメージを`docker save`/`scp`/`docker load`でEC2に転送してコンテナ実行のみ行う方式に一本化した
- Terraformの責務（AWSインフラ構築・EC2初期セットアップ）とアプリケーションデプロイの責務（build・転送・起動）を分離した
- インフラ構成・デプロイ方式をREADME/開発仕様書/incidentsに整理してドキュメント化した
- CLAUDE.mdにTerraform品質チェック項目を追加した

## 変更内容

### 構成の一本化
- `docker-compose.prod.local-build.yml`（image参照方式）の内容を`docker-compose.prod.yml`に統合し、build方式のcomposeファイルを廃止
- `terraform/user_data.sh.tpl`からgit clone・アプリbuild・起動処理を削除し、Docker/Docker Compose本体のインストールのみに限定
- `terraform/variables.tf`・`main.tf`・`outputs.tf`から、アプリケーションのシークレット（JWT_SECRET_KEY等）に関する変数・リソース（`random_password`等）を削除。これらはTerraformの責務外とし、`deploy/`側で扱う
- `deploy/deploy.sh`を新規追加：ローカルbuild→`docker save`→`scp`→`docker load`→`docker compose up`を自動化するデプロイスクリプト
- `deploy/env.prod.example`を新規追加：本番用`.env`のサンプル（実値は含まない）

### ドキュメント
- README.md：「本番デプロイ構成（AWS）」節を追加（インフラ構成図、Terraform/デプロイスクリプトの責務分担、ローカルビルド方式のMermaid図）
- 開発仕様書：「3.1 本番環境との違い」「3.2 設計判断：EC2上でのbuildを採用しなかった理由」を追加
- docs/incidents/2026-09-03-ec2-build-oom.md：t3.microのメモリ不足によるSSH不通の実機調査記録を新規追加
- CLAUDE.md：「Terraform品質チェック」節を追加（fmt/validate/plan/機密情報/不要リソース/SGポートの確認項目）

## ドキュメントの役割分担
- **README.md**：プロジェクト全体から見たAWS本番構成・インフラ構成図
- **開発仕様書**：開発環境と本番環境の構成差分・設計判断の経緯
- **docs/incidents**：今回発生したメモリ不足・SSH不通の実機調査の事実記録
- **CLAUDE.md**：Terraformを含むインフラ変更時の品質チェック手順

Closes #76

## Test plan
- [x] `terraform fmt -check -recursive`：フォーマット崩れなし
- [x] `terraform validate`：Success
- [x] `terraform plan`：5リソース作成のみ（EC2, SG, キーペア, tls_private_key, local_sensitive_file）。想定外のリソースなし
- [x] 機密情報チェック：`.tf`/`.tfvars`/コミット対象に機密情報が含まれないことを確認（`terraform.tfstate.backup`に残っていた秘密鍵の残骸はGit管理外で削除済み）
- [x] Security Groupの公開ポート確認：22(SSH) / 3000(frontend) / 8000(backend)のみ。3306(MySQL)は非公開
- [x] `deploy/deploy.sh`の構文チェック（`bash -n`）
- [x] `npm run lint` / `npx tsc --noEmit`（frontend、アプリコードは無変更のため影響なし）
- [x] CI（backend/frontend）成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)